### PR TITLE
MRCC correlation and SCF energy + JKQC display

### DIFF
--- a/JKQC/src/arguments.py
+++ b/JKQC/src/arguments.py
@@ -747,6 +747,12 @@ def arguments(argument_list = []):
     if i == "-elc" or i == "--elc":
       Pout.append("-elc")
       continue
+    if i == "-elscf" or i == "--elscf":
+      Pout.append("-elscf")
+      continue
+    if i == "-elcorr" or i == "--elcorr":
+      Pout.append("-elcorr")
+      continue
     if i == "-g" or i == "-gibbs" or i == "--g" or i == "--gibbs":
       Pout.append("-g")
       continue

--- a/JKQC/src/print_output.py
+++ b/JKQC/src/print_output.py
@@ -414,6 +414,20 @@ def print_output(clusters_df, Qoutpkl, input_pkl, output_pkl, Qsplit, Qclusterna
       except:
         output.append([missing]*len(clusters_df))
       continue
+    # el SCF 
+    if i == "-elscf":
+      try:
+        output.append(QUenergy*(clusters_df.loc[:,("log","scf_energy")]))
+      except:
+        output.append([missing]*len(clusters_df))
+      continue
+    # actual el corr??
+    if i == "-elcorr":
+      try:
+        output.append(QUenergy*(clusters_df.loc[:,("log","correlation_energy")]))
+      except:
+        output.append([missing]*len(clusters_df))
+      continue
     # energy th corr.
     if i == "-uc":
       try:

--- a/JKQC/src/read_mrcc.py
+++ b/JKQC/src/read_mrcc.py
@@ -35,7 +35,7 @@ def read_mrcc(mmm):
   from io import open
   missing = float("nan")
 
-  columns = ["program","method","time","electronic_energy"]
+  columns = ["program","method","time","electronic_energy","scf_energy","correlation_energy"]
 
   #PROGRAM VERSION
   #try:
@@ -60,14 +60,25 @@ def read_mrcc(mmm):
     out_time =out_time.total_seconds() / 60
   except:
     out_time = missing
-
+  #NOTE: MRCC for some reason has unique text for each type of calculations, these will only work for LNO-CCSD(T) methods...
   #ELECTRONIC ENERGY
   try:
     line,idx = find_line(rb'Total LNO-CCSD(T) energy with MP2 corrections', 0, 0)
     out_electronic_energy = float(line.split()[7])
   except:
     out_electronic_energy = missing
-
+  #SCF ENERGY
+  try:
+    line,idx = find_line(rb'Reference energy', 0, 0)
+    out_scf_energy = float(line.split()[3])
+  except:
+    out_scf_energy = missing
+  #CORRELATION ENERGY
+  try:
+    line,idx = find_line(rb'CCSD(T) correlation energy + MP2 corrections', 0, 0)
+    out_correlation_energy = float(line.split()[7])
+  except:
+    out_correlation_energy = missing
   #SAVE
   mm.close()
   all_locals = locals()


### PR DESCRIPTION
read_mrcc now stores the correlation energy and reference (SCF) energy. These are needed for extrapolations.
Added "-elcorr" and "-elscf" as keywords to JKQC. 