### PR TITLE
[WIP] Add support for various k-NN model variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ output
 .run1
 TEST
 TMP
+# compiled fortran files
+*.so
+*.mod
+*.o

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -65,7 +65,7 @@ from src.load_databases import load_databases
 ###### SAMPLEEACH/SIMILARITY ######
 ###################################
 
-if Qtrain == 0:
+if Qtrain == 0 and not Qhyper:
     print("JKML: training option is missing [EXITING]", flush=True)
     exit()
 

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -281,7 +281,7 @@ for sampleeach_i in sampleeach_all:
             f.close()
             print("JKML: Trained model loaded.", flush=True)
             # store the training metadata to locals
-            locals.update(train_metadata)
+            locals().update(train_metadata)
         elif Qmethod == "knn":
             import pickle
             from sklearn.neighbors import KNeighborsRegressor
@@ -305,7 +305,7 @@ for sampleeach_i in sampleeach_all:
             knn = KNeighborsRegressor(**knn_params)
             knn.fit(X_train, Y_train)
             # store the training metadata to locals
-            locals.update(train_metadata)
+            locals().update(train_metadata)
         elif Qmethod == "nn" or Qmethod == "physnet":
             varsoutfile = VARS_PKL
             print("JKML: Trained model found.")

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -178,8 +178,8 @@ for sampleeach_i in sampleeach_all:
                     Qrepresentation,
                     strs,
                     Y_train,
-                    krr_cutoff,
                     varsoutfile,
+                    krr_cutoff,
                     no_metric=no_metric,
                 )
             )

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -169,6 +169,7 @@ for sampleeach_i in sampleeach_all:
                     Qsplit_j,
                 )
             )
+        #####################################
         elif Qmethod == "knn":
             from src.QKNN import training
 
@@ -341,8 +342,10 @@ for sampleeach_i in sampleeach_all:
         if Qmethod == "krr":
             from src.QML import evaluate
 
-            Y_predicted = evaluate(
-                Qrepresentation, krr_cutoff, X_train, sigmas, alpha, strs, Qkernel
+            Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test = (
+                evaluate(
+                    Qrepresentation, krr_cutoff, X_train, sigmas, alpha, strs, Qkernel
+                )
             )
             Qforces = 0
             F_predicted = None
@@ -351,7 +354,9 @@ for sampleeach_i in sampleeach_all:
         elif Qmethod == "knn":
             from src.QKNN import evaluate
 
-            Y_predicted = evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn)
+            Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test = (
+                evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn)
+            )
             Qforces = 0
             F_predicted = None
             Qa_predicted = None
@@ -409,6 +414,17 @@ for sampleeach_i in sampleeach_all:
             Qcharge,
             Q_charges,
             Qa_predicted,
+            repr_train_wall,
+            repr_train_cpu,
+            repr_test_wall,
+            repr_test_cpu,
+            train_wall,
+            train_cpu,
+            test_wall,
+            test_cpu,
+            n_train,
+            d_train,
+            X_train.shape[0],
         )
 
     ####################################################################################################

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -48,6 +48,7 @@ from src.load_databases import load_databases
     Qeval,
     Qopt,
     Qmonomers,
+    Qhyper,
     method,
     VARS_PKL,
     TRAIN_HIGH,

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -289,7 +289,7 @@ for sampleeach_i in sampleeach_all:
 
             warn("Loading KNN models is untested, and may not work properly!")
 
-            with open(VARS_PKL, "wb") as f:
+            with open(VARS_PKL, "rb") as f:
                 if not no_metric:
                     X_train, Y_train, X_atoms, A, mlkr, knn_params, train_metadata = (
                         pickle.load(f)

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -510,7 +510,33 @@ for sampleeach_i in sampleeach_all:
     #########################
 
     if Qhyper:
-        print("JKML is starting hyperparameter optimisation.")
+        ### DATABASE LOADING ###
+        print("JKML is preparing things for training.", flush=True)
+        from src.data import prepare_data_for_training as prepare_data
+
+        # returns: strs, Y_train, F_train, Qforces, Q_charge, Q_charges, Qcharge, D_dipole, Qdipole, size
+        locals().update(
+            prepare_data(
+                train_high_database,
+                monomers_high_database,
+                train_low_database,
+                monomers_low_database,
+                seed,
+                size,
+                method,
+                column_name_1,
+                column_name_2,
+                Qmin,
+                Qifforces,
+                Qifcharges,
+                Qifdipole,
+                Qsampleeach,
+                Qforcemonomers,
+                sampledist,
+                Qmonomers,
+            )
+        )
+        print("JKML is starting hyperparameter optimisation.", flush=True)
         if Qmethod == "knn":
             from src.QKNN import hyperopt
 

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -502,6 +502,37 @@ for sampleeach_i in sampleeach_all:
         # clustersout_df.to_pickle(outfile)
     ########
 
+    ####################################################################################################
+    ####################################################################################################
+
+    #########################
+    ###### HYPERPARAMS ######
+    #########################
+
+    if Qhyper:
+        print("JKML is starting hyperparameter optimisation.")
+        if Qmethod == "knn":
+            from src.QKNN import hyperopt
+
+            params = hyperopt(Qrepresentation, strs, Y_train, varsoutfile, nometric)
+
+        else:
+            raise ValueError(
+                f"Hyperparameter optimisation not implemented for {Qmethod}!"
+            )
+        print(f"JKML: optimal parameters:")
+        print("{:<10} {:<10}".format("Parameter", "Value"))
+        if "representation" in params:
+            print("-------Representation-------")
+            for k, v in params["representation"].items():
+                print("{:<10} {:<10}".format(k, v))
+        if "knn" in params:
+            print("-------KNN-------")
+            for k, v in params["knn"].items():
+                print("{:<10} {:<10}".format(k, v))
+        print("", flush=True)
+
+
 ####################################################################################################
 ####################################################################################################
 print("\nJKML has finished", flush=True)

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -273,13 +273,15 @@ for sampleeach_i in sampleeach_all:
             import pickle
 
             if Qrepresentation == "fchl":
-                X_train, sigmas, alpha = pickle.load(f)
+                X_train, sigmas, alpha, train_metadata = pickle.load(f)
             elif Qrepresentation == "mbdf":
-                X_train, X_atoms, sigmas, alpha = pickle.load(f)
+                X_train, X_atoms, sigmas, alpha, train_metadata = pickle.load(f)
             if len(alpha) != 1:
                 alpha = [alpha]
             f.close()
             print("JKML: Trained model loaded.", flush=True)
+            # store the training metadata to locals
+            locals.update(train_metadata)
         elif Qmethod == "knn":
             import pickle
             from sklearn.neighbors import KNeighborsRegressor
@@ -288,12 +290,22 @@ for sampleeach_i in sampleeach_all:
             warn("Loading KNN models is untested, and may not work properly!")
 
             with open(VARS_PKL, "wb") as f:
-                X_train, Y_train, X_atoms, A, mlkr, knn_params = pickle.load(f)
+                if not no_metric:
+                    X_train, Y_train, X_atoms, A, mlkr, knn_params, train_metadata = (
+                        pickle.load(f)
+                    )
+                else:
+                    X_train, Y_train, X_atoms, knn_params, train_metadata = pickle.load(
+                        f
+                    )
 
             # need to recreate the model due to not being able to pickle the custom metric
-            knn_params["metric"] = mlkr.get_metric()
+            if not no_metric:
+                knn_params["metric"] = mlkr.get_metric()
             knn = KNeighborRegressor(**knn_params)
             knn.fit(X_train, Y_train)
+            # store the training metadata to locals
+            locals.update(train_metadata)
         elif Qmethod == "nn" or Qmethod == "physnet":
             varsoutfile = VARS_PKL
             print("JKML: Trained model found.")

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -424,7 +424,7 @@ for sampleeach_i in sampleeach_all:
             test_cpu,
             n_train,
             d_train,
-            X_train.shape[0],
+            d_test,
         )
 
     ####################################################################################################

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -296,8 +296,6 @@ for sampleeach_i in sampleeach_all:
                         X_train,
                         Y_train,
                         X_atoms,
-                        K_train,
-                        D_train,
                         knn_params,
                         train_metadata,
                     ) = pickle.load(f)
@@ -389,7 +387,6 @@ for sampleeach_i in sampleeach_all:
                     X_train,
                     strs,
                     knn,
-                    K_train=K_train,
                     hyper_cache=hyper_cache,
                 )
             )

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -541,7 +541,7 @@ for sampleeach_i in sampleeach_all:
         if Qmethod == "knn":
             from src.QKNN import hyperopt
 
-            params = hyperopt(Qrepresentation, strs, Y_train, varsoutfile, nometric)
+            params = hyperopt(Qrepresentation, strs, Y_train, varsoutfile, no_metric)
 
         else:
             raise ValueError(

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -285,9 +285,6 @@ for sampleeach_i in sampleeach_all:
         elif Qmethod == "knn":
             import pickle
             from sklearn.neighbors import KNeighborsRegressor
-            from warnings import warn
-
-            warn("Loading KNN models is untested, and may not work properly!")
 
             with open(VARS_PKL, "rb") as f:
                 if not no_metric:

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -302,7 +302,7 @@ for sampleeach_i in sampleeach_all:
             # need to recreate the model due to not being able to pickle the custom metric
             if not no_metric:
                 knn_params["metric"] = mlkr.get_metric()
-            knn = KNeighborRegressor(**knn_params)
+            knn = KNeighborsRegressor(**knn_params)
             knn.fit(X_train, Y_train)
             # store the training metadata to locals
             locals.update(train_metadata)

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -297,6 +297,7 @@ for sampleeach_i in sampleeach_all:
                         Y_train,
                         X_atoms,
                         knn_params,
+                        vp_params,
                         train_metadata,
                     ) = pickle.load(f)
                 else:
@@ -311,12 +312,14 @@ for sampleeach_i in sampleeach_all:
                     ) = pickle.load(f)
 
             # need to recreate the model due to not being able to pickle the custom metric
-            if not no_metric:
+            if not no_metric and Qrepresentation != "fchl-kernel":
                 knn_params["metric"] = mlkr.get_metric()
-            knn = KNeighborsRegressor(**knn_params)
-            if Qrepresentaion == "fchl-kernel":
-                knn.fit(D_train, Y_train)
+            if Qrepresentation == "fchl-kernel":
+                from src.QKNN import load_vp_knn
+
+                knn = load_vp_knn(X_train, Y_train, vp_params, **knn_params)
             else:
+                knn = KNeighborsRegressor(**knn_params)
                 knn.fit(X_train, Y_train)
             # store the training metadata to locals
             locals().update(train_metadata)
@@ -573,22 +576,27 @@ for sampleeach_i in sampleeach_all:
         if Qmethod == "knn":
             from src.QKNN import hyperopt
 
-            params = hyperopt(Qrepresentation, strs, Y_train, varsoutfile, no_metric)
-
+            params = hyperopt(
+                Qrepresentation,
+                strs,
+                Y_train,
+                varsoutfile,
+                no_metric,
+                hyper_cache=hyper_cache,
+            )
         else:
             raise ValueError(
                 f"Hyperparameter optimisation not implemented for {Qmethod}!"
             )
         print(f"JKML: optimal parameters:")
-        print("{:<10} {:<10}".format("Parameter", "Value"))
         if "representation" in params:
             print("-------Representation-------")
             for k, v in params["representation"].items():
-                print("{:<10} {:<10}".format(k, v))
+                print(f"{k}: {v}")
         if "knn" in params:
             print("-------KNN-------")
             for k, v in params["knn"].items():
-                print("{:<10} {:<10}".format(k, v))
+                print(f"{k}: {v}")
         print("", flush=True)
 
 

--- a/JKML/JKML.py
+++ b/JKML/JKML.py
@@ -180,8 +180,8 @@ for sampleeach_i in sampleeach_all:
                     strs,
                     Y_train,
                     varsoutfile,
-                    krr_cutoff,
                     no_metric=no_metric,
+                    hyper_cache=hyper_cache,
                 )
             )
         #####################################
@@ -356,7 +356,7 @@ for sampleeach_i in sampleeach_all:
             from src.QKNN import evaluate
 
             Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test = (
-                evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn)
+                evaluate(Qrepresentation, X_train, strs, knn, hyper_cache=hyper_cache)
             )
             Qforces = 0
             F_predicted = None

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -232,7 +232,8 @@ def training(
     train_cpu_start = time.process_time()
     if not no_metric:
         print("JKML(Q-kNN): Training MLKR metric.", flush=True)
-        mlkr = MLKR()
+        # Limit the number of MLKR components for faster training
+        mlkr = MLKR(n_components=50)
         mlkr.fit(X_train, Y_train)
         A = mlkr.get_mahalanobis_matrix()
         print("JKML(Q-kNN): Training k-NN regressor with MLKR metric.")

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -363,7 +363,7 @@ def hyperopt(
         objective, space, n_calls=30, random_state=42, verbose=verbose
     )
     elapsed = time.perf_counter() - start_time
-    print(f"JKML: Hyperparameter tuning done, took {elapsed:.2f} s.")
+    print(f"JKML: Hyperparameter tuning done, took {elapsed:.2f} s.", flush=True)
     params = {}
     for s, v in zip(space, res.x):
         if s.name in knn_param_names:

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -178,13 +178,15 @@ def load_hyperparams(hyper_cache: str):
     if hyper_cache is not None:
         with open(hyper_cache, "rb") as f:
             hyperparams = pickle.load(f)
-        print(f"JKML(Q-kNN): Loaded hyperparameters from {hyper_cache}.")
+        print(f"JKML(Q-kNN): Loaded hyperparameters from {hyper_cache}:", flush=True)
+        print(hyperparams, flush=True)
     else:
         # use defaults
         hyperparams = {
             "knn": {"n_neighbors": 5, "weights": "uniform"},
             "representation": {"cutoff": 8.0},
         }
+        print(f"JKML(Q-kNN): Using default hyperparams {hyperparams}", flush=True)
     return hyperparams
 
 

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -47,9 +47,14 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
 def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
+    n = len(strs)
+    ragged_atomic_numbers = np.empty(n, dtype=object)
+    ragged_atomic_numbers[:] = [i.get_atomic_numbers() for i in strs]
+    ragged_positions = np.empty(n, dtype=object)
+    ragged_positions[:] = [i.get_positions() for i in strs]
     X = generate_representation(
-        [i.get_atomic_numbers() for i in strs],
-        [i.get_positions() for i in strs],
+        ragged_atomic_numbers,
+        ragged_positions,
         cutoff_r=cutoff,
         normalized=False,
         local=False,

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -313,12 +313,12 @@ def hyperopt(
     # hard-coded search spaces (for now)
     if Qrepresentation == "fchl":
         space = {
-            "rcut": skopt.space.Real(0.1, 20, prior="log-uniform"),
-            "acut": skopt.space.Real(0.1, 20, prior="log-uniform"),
+            "rcut": skopt.space.Real((0.1, 20, "log-uniform")),
+            "acut": skopt.space.Real((0.1, 20, "log-uniform")),
         }
     elif Qrepresentation == "mbdf":
         space = {
-            "cutoff": skopt.space.Real(0.1, 20, prior="log-uniform"),
+            "cutoff": skopt.space.Real((0.1, 20, "log-uniform")),
         }
     elif Qrepresentation == "mbtr":
         # these values are based on stuke2021efficient
@@ -335,7 +335,7 @@ def hyperopt(
     # TODO: add time print
 
     # add k-nn specific hyperparameter
-    space["n_neighbors"] = skopt.space.Integer(3, 15)
+    space["n_neighbors"] = skopt.space.Integer((3, 15))
     space["weights"] = skopt.space.Categorical(["uniform", "distance"])
 
     knn_param_names = ["n_neighbors", "weights"]

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -151,7 +151,7 @@ def training(
         Qrepresentation, strs, krr_cutoff, max_atoms, asize
     )
     repr_train_wall = time.perf_counter() - repr_wall_start
-    repr_train_cpu = time.perf_counter() - repr_cpu_start
+    repr_train_cpu = time.process_time() - repr_cpu_start
 
     # some info about the full representation
     print(
@@ -177,7 +177,7 @@ def training(
         knn = KNeighborsRegressor(n_jobs=-1, algorithm="auto")
     knn.fit(X_train, Y_train)
     train_wall = time.perf_counter() - train_wall_start
-    train_cpu = time.perf_counter() - train_cpu_start
+    train_cpu = time.process_time() - train_cpu_start
     n_train, d_train = X_train.shape
     print("JKML(Q-kNN): Training completed.", flush=True)
     knn_params = knn.get_params()
@@ -221,7 +221,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn_model):
     repr_cpu_start = time.process_time()
     X_test = calculate_representation(Qrepresentation, strs, krr_cutoff)
     repr_test_wall = time.perf_counter() - repr_wall_start
-    repr_test_cpu = time.perf_counter() - repr_cpu_start
+    repr_test_cpu = time.process_time() - repr_cpu_start
 
     # some info about the full representation
     print(
@@ -254,7 +254,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn_model):
     test_cpu_start = time.process_time()
     Y_predicted = knn_model.predict(X_test)
     test_wall = time.perf_counter() - test_wall_start
-    test_cpu = time.perf_counter() - test_cpu_start
+    test_cpu = time.process_time() - test_cpu_start
     Y_predicted = Y_predicted[None, :]
     d_test = X_test.shape[1]
     return Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -316,24 +316,24 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
 
     ### CORRECTING THE FCHL MATRIX SIZES
     # IF YOU ARE EXTENDING THIS WILL MAKE THE MATRIXES OF THE SAME SIZE
-    if Qrepresentation == "fchl":
-        if X_train.shape[1] != X_test.shape[1]:
-            if X_train.shape[1] > X_test.shape[1]:
-                small = X_test
-                large = X_train
-            else:
-                small = X_train
-                large = X_test
-            newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
-            newmatrix[:, :, 0, :] = 1e100
-            newmatrix[
-                0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]
-            ] = small
-            if X_train.shape[1] > X_test.shape[1]:
-                X_test = newmatrix
-            else:
-                X_train = newmatrix
-
+#    if Qrepresentation == "fchl":
+#        if X_train.shape[1] != X_test.shape[1]:
+#            if X_train.shape[1] > X_test.shape[1]:
+#                small = X_test
+#                large = X_train
+#            else:
+#                small = X_train
+#                large = X_test
+#            newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
+#            newmatrix[:, :, 0, :] = 1e100
+#            newmatrix[
+#                0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]
+#            ] = small
+#            if X_train.shape[1] > X_test.shape[1]:
+#                X_test = newmatrix
+#            else:
+#                X_train = newmatrix
+#
     ### THE EVALUATION
     test_wall_start = time.perf_counter()
     test_cpu_start = time.process_time()

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -403,7 +403,7 @@ def hyperopt(
 
     start_time = time.perf_counter()
     res = skopt.gp_minimize(
-        objective, space, n_calls=30, random_state=42, verbose=verbose
+        objective, space, n_calls=50, random_state=42, verbose=verbose
     )
     elapsed = time.perf_counter() - start_time
     print(f"JKML: Hyperparameter tuning done, took {elapsed:.2f} s.", flush=True)

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -444,6 +444,27 @@ class VPTreeKNN:
             w = 1 / D
             return np.average(Y, weights=w, axis=1)
 
+    def get_params(self, deep=True):
+        """
+        Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        out = dict()
+        out["n_neighbors"] = self.k
+        out["weights"] = self.weights
+        out["n_jobs"] = self.max_workers
+        return out
+
 
 def fast_kernel(
     alchemy: str = "periodic-table",

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -47,13 +47,24 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
 def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
-    X = generate_representation(
-        np.array([i.get_atomic_numbers() for i in strs]),
-        np.array([i.get_positions() for i in strs]),
+    n = len(strs)
+    representation = generate_representation(
+        strs[0].get_atomic_numbers(),
+        strs[0].get_positions(),
         cutoff_r=cutoff,
         normalized=False,
         local=False,
     )
+    X = np.zeros((n, representation.shape[1]))
+    X[0, :] = representation
+    for i in range(1, n):
+        X[i, :] = generate_representation(
+            strs.iloc[i].get_atomic_numbers(),
+            strs.iloc[i].get_positions(),
+            cutoff_r=cutoff,
+            normalized=False,
+            local=False,
+        )
     return X
 
 

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -247,6 +247,7 @@ def training(
     knn_params = knn.get_params()
     knn_params["metric"] = "MLKR_placeholder"
     with open(varsoutfile, "wb") as f:
+        print(f"JKML(Q-kNN): Saving training data to {varsoutfile}")
         if not no_metric:
             pickle.dump([X_train, Y_train, X_atoms, A, mlkr, knn_params], f)
         else:
@@ -416,5 +417,6 @@ def hyperopt(
 
     with open(hyperparamfile, "wb") as f:
         pickle.dump(params, f)
+        print(f"JKML(Q-kNN): Saved hyperparams to {hyperparamfile}")
 
     return params

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -47,24 +47,13 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
 def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
-    n = len(strs)
-    representation = generate_representation(
-        strs[0].get_atomic_numbers(),
-        strs[0].get_positions(),
+    X = generate_representation(
+        [i.get_atomic_numbers() for i in strs],
+        [i.get_positions() for i in strs],
         cutoff_r=cutoff,
         normalized=False,
         local=False,
     )
-    X = np.zeros((n, representation.shape[1]))
-    X[0, :] = representation
-    for i in range(1, n):
-        X[i, :] = generate_representation(
-            strs[i].get_atomic_numbers(),
-            strs[i].get_positions(),
-            cutoff_r=cutoff,
-            normalized=False,
-            local=False,
-        )
     return X
 
 

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -26,7 +26,7 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
     n = len(strs)
     representation = generate_representation(
         strs[0].get_atomic_numbers(),
-        strs[1].get_positions(),
+        strs[0].get_positions(),
         rcut=rcut,
         acut=acut,
     )

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -13,15 +13,15 @@ from collections import defaultdict
 import time
 
 
-def _generate_fchl19(strs: List[Atoms], krr_cutoff: float = 8) -> np.ndarray:
+def _generate_fchl19(strs: List[Atoms], cutoff: float = 8, **kwargs) -> np.ndarray:
     from qmllib.representations import generate_fchl19 as generate_representation
 
     n = len(strs)
     representation = generate_representation(
         strs[0].get_atomic_numbers(),
         strs[1].get_positions(),
-        rcut=krr_cutoff,
-        acut=krr_cutoff,
+        rcut=cutoff,
+        acut=cutoff,
     )
     X = np.zeros((n, representation.shape[1]))
     X[0, :] = np.sum(representation, axis=0)
@@ -29,21 +29,21 @@ def _generate_fchl19(strs: List[Atoms], krr_cutoff: float = 8) -> np.ndarray:
         X[i, :] = generate_representation(
             strs.iloc[i].get_atomic_numbers(),
             strs.iloc[i].get_positions(),
-            rcut=krr_cutoff,
-            acut=krr_cutoff,
+            rcut=cutoff,
+            acut=cutoff,
         ).sum(axis=0)
     if np.isnan(X).any():
         raise ValueError("NaNs in FCHL representation!")
     return X
 
 
-def _generate_mbdf(strs: List[Atoms], cutoff_r: float) -> np.ndarray:
+def _generate_mbdf(strs: List[Atoms], cutoff: float, **kwargs) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
     X = generate_representation(
         np.array([i.get_atomic_numbers() for i in strs]),
         np.array([i.get_positions() for i in strs]),
-        cutoff_r=cutoff_r,
+        cutoff_r=cutoff,
         normalized=False,
         local=False,
     )
@@ -51,7 +51,7 @@ def _generate_mbdf(strs: List[Atoms], cutoff_r: float) -> np.ndarray:
 
 
 def _generate_bob(
-    strs: List[Atoms], max_atoms: int, asize: Dict[str, Union[np.int64, int]]
+    strs: List[Atoms], max_atoms: int, asize: Dict[str, Union[np.int64, int]], **kwargs
 ):
     from qmllib.representations import generate_bob as generate_representation
 
@@ -91,7 +91,7 @@ def _generate_bob(
     return X
 
 
-def _generate_coulomb(strs: List[Atoms], max_atoms: int):
+def _generate_coulomb(strs: List[Atoms], max_atoms: int, **kwargs):
     from qmllib.representations import (
         generate_coulomb_matrix as generate_representation,
     )
@@ -116,6 +116,7 @@ def _generate_mbtr(
     geometry={"function": "inverse_distance"},
     grid={"min": 0, "max": 1, "n": 100, "sigma": 0.1},
     weighting={"function": "exp", "scale": 0.5, "threshold": 1e-3},
+    **kwargs,
 ):
     from dscribe.descriptors import MBTR
 
@@ -175,7 +176,7 @@ def training(
     )
     X_atoms = [strs[i].get_atomic_numbers() for i in range(len(strs))]
     X_train = calculate_representation(
-        Qrepresentation, strs, krr_cutoff=krr_cutoff, max_atoms=max_atoms, asize=asize
+        Qrepresentation, strs, cutoff=krr_cutoff, max_atoms=max_atoms, asize=asize
     )
     repr_train_wall = time.perf_counter() - repr_wall_start
     repr_train_cpu = time.process_time() - repr_cpu_start

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -301,7 +301,7 @@ class VPTreeKNN:
     ):
         self.kernel = kernel_fun
         self.k = n_neighbors
-        self.max_workers = (
+        self.max_workers = int(
             os.environ.get("SLURM_CPUS_PER_TASK", os.cpu_count())
             if n_jobs == -1
             else n_jobs
@@ -934,6 +934,7 @@ def hyperopt(
             mlkrs = []
 
         for i, (train_index, test_index) in enumerate(kf.split(X)):
+            fold_start = time.perf_counter()
             X_fold, Y_fold = X[train_index], Y_train[train_index]
             X_test = X[test_index]
             if no_metric:
@@ -962,6 +963,8 @@ def hyperopt(
                 # Y_fold is still a vector; can index directly
                 Y_sorted = Y_fold[sorted_indices]
             sorted_Ys.append(Y_sorted)
+            print(f"\tFold {i+1}/{cv_folds} done, took {time.perf_counter() - fold_start:.1f} s.", flush=True)
+
 
         print(
             f"JKML(k-NN): Precalculation done, took {time.perf_counter() - precalc_start:.1f} s.",

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -247,7 +247,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, strs, knn_model):
     X_atoms = [strs[i].get_atomic_numbers() for i in range(len(strs))]
     repr_wall_start = time.perf_counter()
     repr_cpu_start = time.process_time()
-    X_test = calculate_representation(Qrepresentation, strs, krr_cutoff)
+    X_test = calculate_representation(Qrepresentation, strs, cutoff=krr_cutoff)
     repr_test_wall = time.perf_counter() - repr_wall_start
     repr_test_cpu = time.process_time() - repr_cpu_start
 

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -699,7 +699,7 @@ def training(
     knn.fit(X_train, Y_train)
     train_wall = time.perf_counter() - train_wall_start
     train_cpu = time.process_time() - train_cpu_start
-    n_train, d_train = X_train.shape
+    n_train, d_train = X_train.shape[0], np.sum(X_train.shape[1:])
     train_metadata = {
         "repr_train_wall": repr_train_wall,
         "repr_train_cpu": repr_train_cpu,
@@ -904,6 +904,8 @@ def hyperopt(
 
     else:
 
+        print("JKML(k-NN): Precalculating distance matrices for hyperopt.", flush=True)
+        precalc_start = time.perf_counter()
         # precalculate distances and sorted Y matrices for SPEED
         kf = KFold(cv_folds)
         # could preallocate, but won't bother >:)
@@ -944,6 +946,7 @@ def hyperopt(
                 Y_sorted = Y_fold[sorted_indices]
             sorted_Ys.append(Y_sorted)
 
+        print(f"JKML(k-NN): Precalculation done, took {time.perf_counter() - precalc_start:.1f} s.", flush=True)
         @skopt.utils.use_named_args(space)
         @lru_cache
         def objective(n_neighbors, weights, **repr_params):

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -258,7 +258,8 @@ def training(
     }
     print("JKML(Q-kNN): Training completed.", flush=True)
     knn_params = knn.get_params()
-    knn_params["metric"] = "MLKR_placeholder"
+    if not no_metric:
+        knn_params["metric"] = "MLKR_placeholder"
     with open(varsoutfile, "wb") as f:
         print(f"JKML(Q-kNN): Saving training data to {varsoutfile}")
         if not no_metric:

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -358,7 +358,7 @@ def hyperopt(
         )
 
     start_time = time.perf_counter()
-    res = skopt.gb_minimize(
+    res = skopt.gp_minimize(
         objective, space, n_calls=30, random_state=42, verbose=verbose
     )
     elapsed = time.perf_counter() - start_time

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -34,8 +34,8 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
     X[0, :] = np.sum(representation, axis=0)
     for i in range(1, n):
         X[i, :] = generate_representation(
-            strs.iloc[i].get_atomic_numbers(),
-            strs.iloc[i].get_positions(),
+            strs[i].get_atomic_numbers(),
+            strs[i].get_positions(),
             rcut=rcut,
             acut=acut,
         ).sum(axis=0)
@@ -59,8 +59,8 @@ def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarr
     X[0, :] = representation
     for i in range(1, n):
         X[i, :] = generate_representation(
-            strs.iloc[i].get_atomic_numbers(),
-            strs.iloc[i].get_positions(),
+            strs[i].get_atomic_numbers(),
+            strs[i].get_positions(),
             cutoff_r=cutoff,
             normalized=False,
             local=False,

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -207,6 +207,9 @@ def training(
 
     hyperparams = load_hyperparams(hyper_cache)
     # Convert structures to list to avoid indexing issues
+    for i, struct in enumerate(strs.values):
+        assert struct == strs.iloc[i]
+    print("Values works!")
     strs = strs.values
     ### REPRESENTATION CALCULATION ###
     repr_wall_start = time.perf_counter()
@@ -302,6 +305,10 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
 
     hyperparams = load_hyperparams(hyper_cache)
     ### REPRESENTATION CALCULATION ###
+    # Convert structures to list to avoid indexing issues
+    for i, struct in enumerate(strs.values):
+        assert struct == strs.iloc[i]
+    strs = strs.values
     X_atoms = [strs[i].get_atomic_numbers() for i in range(len(strs))]
     repr_wall_start = time.perf_counter()
     repr_cpu_start = time.process_time()
@@ -365,6 +372,11 @@ def hyperopt(
     from functools import lru_cache
     from sklearn.model_selection import cross_val_score
 
+
+    # Convert structures to list to avoid indexing issues
+    for i, struct in enumerate(strs.values):
+        assert struct == strs.iloc[i]
+    strs = strs.values
     # hard-coded search spaces (for now)
     space = []
     if optimise_representation:

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -383,7 +383,7 @@ def hyperopt(
     )
     elapsed = time.perf_counter() - start_time
     print(f"JKML: Hyperparameter tuning done, took {elapsed:.2f} s.", flush=True)
-    params = {}
+    params = {"knn": {}, "representation": {}}
     for s, v in zip(space, res.x):
         if s.name in knn_param_names:
             params["knn"][s.name] = v

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -8,7 +8,7 @@ import pickle
 from sklearn.neighbors import KNeighborsRegressor
 from metric_learn import MLKR
 from ase.atoms import Atoms
-from typing import List, Tuple, Union, Dict
+from typing import Iterable, Tuple, Union, Dict
 import os
 from collections import defaultdict
 import time
@@ -21,7 +21,7 @@ warnings.filterwarnings(
 )
 
 
-def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndarray:
+def _generate_fchl19(strs: Iterable[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndarray:
     from qmllib.representations import generate_fchl19 as generate_representation
 
     n = len(strs)
@@ -45,7 +45,7 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
     return X
 
 
-def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
+def _generate_mbdf(strs: Iterable[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
     n = len(strs)
@@ -64,7 +64,7 @@ def _generate_mbdf(strs: List[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarr
 
 
 def _generate_bob(
-    strs: List[Atoms],
+    strs: Iterable[Atoms],
     max_atoms: int = None,
     asize: Dict[str, Union[np.int64, int]] = None,
     **kwargs,
@@ -107,7 +107,7 @@ def _generate_bob(
     return X
 
 
-def _generate_coulomb(strs: List[Atoms], max_atoms: int = None, **kwargs):
+def _generate_coulomb(strs: Iterable[Atoms], max_atoms: int = None, **kwargs):
     from qmllib.representations import (
         generate_coulomb_matrix as generate_representation,
     )
@@ -128,7 +128,7 @@ def _generate_coulomb(strs: List[Atoms], max_atoms: int = None, **kwargs):
 
 
 def _generate_mbtr(
-    strs: List[Atoms],
+    strs: Iterable[Atoms],
     k2_width=0.1,
     k2_weight=0.5,
     k3_width=0.1,
@@ -163,6 +163,24 @@ def _generate_mbtr(
     return X
 
 
+def _generate_fchl18(strs: Iterable[Atoms], cut_distance=8.0):
+    from qmllib.representations import generate_fchl18 as generate_representation
+
+    max_atoms = max([len(s.get_atomic_numbers()) for s in strs])
+    representations = []
+    for struct in strs:
+        representations.append(
+            generate_representation(
+                struct.get_atomic_numbers(),
+                struct.get_positions(),
+                max_size=max_atoms,
+                neighbors=max_atoms,
+                cut_distance=cut_distance,
+            )
+        )
+    return np.array(representations)
+
+
 def calculate_representation(Qrepresentation, strs, **repr_kwargs):
     if Qrepresentation == "fchl":
         return _generate_fchl19(strs, **repr_kwargs)
@@ -174,10 +192,76 @@ def calculate_representation(Qrepresentation, strs, **repr_kwargs):
         return _generate_coulomb(strs, **repr_kwargs)
     elif Qrepresentation == "mbtr":
         return _generate_mbtr(strs, **repr_kwargs)
+    elif Qrepresentation == "fchl-kernel":
+        return _generate_fchl18(strs, **repr_kwargs)
     else:
         raise NotImplementedError(
             f"Representation 'f{Qrepresentation}' not supported with the k-NN model!"
         )
+
+
+def correct_fchl18_kernel_size(X_test: np.ndarray, X_train: np.ndarray):
+    if X_train.shape[1] != X_test.shape[1]:
+        if X_train.shape[1] > X_test.shape[1]:
+            small = X_test
+            large = X_train
+        else:
+            small = X_train
+            large = X_test
+        newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
+        newmatrix[:, :, 0, :] = 1e100
+        newmatrix[0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]] = (
+            small
+        )
+        if X_train.shape[1] > X_test.shape[1]:
+            X_test = newmatrix
+        else:
+            X_train = newmatrix
+    return X_test, X_train
+
+
+def calculate_kernel(X: np.ndarray, X_other: np.ndarray = None, **kernel_kwargs):
+    from qmllib.representations.fchl import (
+        get_local_symmetric_kernels as JKML_sym_kernel,
+    )
+    from qmllib.representations.fchl import get_local_kernels as JKML_kernel
+
+    if X_other is None:
+        return JKML_kernel(X, X_other, **kernel_kwargs)
+    else:
+        return JKML_sym_kernel(X, **kernel_kwargs)
+
+
+def induced_kernel_distance(
+    K: np.ndarray, K_train: np.ndarray = None, K_test: np.ndarray = None
+):
+
+    def _remove_extra_dim(K: np.ndarray, kernel_name: str):
+        # FCHL kernels return a matrix with an extra leading dimension; this function drops that.
+        if K.ndim > 2:
+            if K.shape[0] == 1:
+                K = K[0]
+            else:
+                raise ValueError(
+                    f"Incompatible {kernel_name} kernel shape! (got shape {K.shape})"
+                )
+        return K
+
+    K = _remove_extra_dim(K, "K")
+    if K_train is None:
+        diag_1 = diag_2 = np.diag(K)
+    else:
+        assert K_test is not None, "Need both self-similarity kernels!"
+        K_train = _remove_extra_dim(K_train, "train")
+        K_test = _remove_extra_dim(K_test, "test")
+        diag_1 = np.diag(K_test)
+        diag_2 = np.diag(K_train)
+    # first two terms broadcast the self-similarities to a [n x m] matrix
+    D_squared = diag_1[:, None] + diag_2[None, :] - 2 * K
+    # get rid of possible numerical problems
+    D_squared = np.maximum(D_squared, 0.0)
+    D = np.sqrt(D_squared)
+    return D
 
 
 def load_hyperparams(hyper_cache: str):
@@ -211,6 +295,7 @@ def training(
         assert struct == strs.iloc[i]
     print("Values works!")
     strs = strs.values
+
     ### REPRESENTATION CALCULATION ###
     repr_wall_start = time.perf_counter()
     repr_cpu_start = time.process_time()
@@ -222,6 +307,10 @@ def training(
     X_train = calculate_representation(
         Qrepresentation, strs, **hyperparams["representation"]
     )
+    if Qrepresentation == "fchl-kernel":
+        print("JKML(k-NN): Calculate train kernels.", flush=True)
+        K_train = calculate_kernel(X_train, **hyperparams["kernel"])
+        D_train = induced_kernel_distance(K_train)
     repr_train_wall = time.perf_counter() - repr_wall_start
     repr_train_cpu = time.process_time() - repr_cpu_start
 
@@ -249,9 +338,14 @@ def training(
             algorithm="ball_tree",
             **hyperparams["knn"],
         )
+        knn.fit(X_train, Y_train)
+    elif Qrepresentation == "fchl-kernel":
+        knn = KNeighborsRegressor(metric="precomputed", n_jobs=-1, **hyperparams["knn"])
+        knn.fit(D_train, Y_train)
     else:
+        # "vanilla" k-NN
         knn = KNeighborsRegressor(n_jobs=-1, algorithm="auto", **hyperparams["knn"])
-    knn.fit(X_train, Y_train)
+        knn.fit(X_train, Y_train)
     train_wall = time.perf_counter() - train_wall_start
     train_cpu = time.process_time() - train_cpu_start
     n_train, d_train = X_train.shape
@@ -264,17 +358,41 @@ def training(
         "d_train": d_train,
     }
     print("JKML(Q-kNN): Training completed.", flush=True)
+    if Qrepresentation != "fchl-kernel":
+        K_train = None
     knn_params = knn.get_params()
     if not no_metric:
         knn_params["metric"] = "MLKR_placeholder"
     with open(varsoutfile, "wb") as f:
         print(f"JKML(Q-kNN): Saving training data to {varsoutfile}")
-        if not no_metric:
+        if no_metric:
+            pickle.dump([X_train, Y_train, X_atoms, knn_params, train_metadata], f)
+        elif Qrepresentation == "fchl-kernel":
             pickle.dump(
-                [X_train, Y_train, X_atoms, A, mlkr, knn_params, train_metadata], f
+                [
+                    X_train,
+                    Y_train,
+                    X_atoms,
+                    K_train,
+                    D_train,
+                    knn_params,
+                    train_metadata,
+                ],
+                f,
             )
         else:
-            pickle.dump([X_train, Y_train, X_atoms, knn_params, train_metadata], f)
+            pickle.dump(
+                [
+                    X_train,
+                    Y_train,
+                    X_atoms,
+                    A,
+                    mlkr,
+                    knn_params,
+                    train_metadata,
+                ],
+                f,
+            )
     return {
         key: value
         for key, value in locals().items()
@@ -282,6 +400,7 @@ def training(
         in [
             "X_train",
             "X_atoms",
+            "K_train",
             "A",
             "knn",
             "repr_train_wall",
@@ -299,7 +418,7 @@ def training(
 ###############################################################################
 
 
-def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
+def evaluate(Qrepresentation, X_train, strs, knn_model, K_train=None, hyper_cache=None):
 
     import numpy as np
 
@@ -315,40 +434,27 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
     X_test = calculate_representation(
         Qrepresentation, strs, **hyperparams["representation"]
     )
+    if Qrepresentation == "fchl-kernel":
+        X_test, X_train = correct_fchl18_kernel_size(X_test, X_train)
+        print("JKML(k-NN): Calculate test kernel(s).", flush=True)
+        K_test = calculate_kernel(X_test)
+        K = calculate_kernel(X_test, X_train)
+        D_test = induced_kernel_distance(K, K_train, K_test)
     repr_test_wall = time.perf_counter() - repr_wall_start
     repr_test_cpu = time.process_time() - repr_cpu_start
 
     # some info about the full representation
     print(
-        "JKML(QML): Shape of the testing representation: " + str(X_test.shape),
+        "JKML(k-NN): Shape of the testing representation: " + str(X_test.shape),
         flush=True,
     )
 
-    ### CORRECTING THE FCHL MATRIX SIZES
-    # IF YOU ARE EXTENDING THIS WILL MAKE THE MATRIXES OF THE SAME SIZE
-    # THIS IS COMMENTED OUT AS IT DOES NOT APPLY TO FCHL'19 (global)
-    #    if Qrepresentation == "fchl":
-    #        if X_train.shape[1] != X_test.shape[1]:
-    #            if X_train.shape[1] > X_test.shape[1]:
-    #                small = X_test
-    #                large = X_train
-    #            else:
-    #                small = X_train
-    #                large = X_test
-    #            newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
-    #            newmatrix[:, :, 0, :] = 1e100
-    #            newmatrix[
-    #                0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]
-    #            ] = small
-    #            if X_train.shape[1] > X_test.shape[1]:
-    #                X_test = newmatrix
-    #            else:
-    #                X_train = newmatrix
-    #
-    ### THE EVALUATION
     test_wall_start = time.perf_counter()
     test_cpu_start = time.process_time()
-    Y_predicted = knn_model.predict(X_test)
+    if Qrepresentation == "fchl-kernel":
+        Y_predicted = knn_model.predict(D_test)
+    else:
+        Y_predicted = knn_model.predict(X_test)
     test_wall = time.perf_counter() - test_wall_start
     test_cpu = time.process_time() - test_cpu_start
     Y_predicted = Y_predicted[None, :]
@@ -408,6 +514,9 @@ def hyperopt(
         )
         global X
         X = calculate_representation(Qrepresentation, strs)
+        if Qrepresentation == "fchl-kernel":
+            K = calculate_kernel(X)
+            X = induced_kernel_distance(K)
 
     # add k-nn specific hyperparameters
     space.append(skopt.space.Integer(3, 15, name="n_neighbors"))

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -175,7 +175,7 @@ def training(
     )
     X_atoms = [strs[i].get_atomic_numbers() for i in range(len(strs))]
     X_train = calculate_representation(
-        Qrepresentation, strs, krr_cutoff, max_atoms, asize
+        Qrepresentation, strs, krr_cutoff=krr_cutoff, max_atoms=max_atoms, asize=asize
     )
     repr_train_wall = time.perf_counter() - repr_wall_start
     repr_train_cpu = time.process_time() - repr_cpu_start

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -403,7 +403,7 @@ def hyperopt(
 
     start_time = time.perf_counter()
     res = skopt.gp_minimize(
-        objective, space, n_calls=50, random_state=42, verbose=verbose
+        objective, space, n_calls=10, random_state=42, verbose=verbose
     )
     elapsed = time.perf_counter() - start_time
     print(f"JKML: Hyperparameter tuning done, took {elapsed:.2f} s.", flush=True)

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -892,7 +892,6 @@ def hyperopt(
             elif Qrepresentation == "fchl-kernel":
                 knn = VPTreeKNN(kernel, n_neighbors=15, weights="uniform")
                 knn.fit(X_fold, Y_fold)
-                # TODO: this maybe works
                 Y_fold, D = knn.k_neighbours(X_test, k=max_k)
             else:
                 mlkr = MLKR(n_components=50)

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -3,6 +3,7 @@
 ###############################################################################
 
 import numpy as np
+import pandas as pd
 import pickle
 from sklearn.neighbors import KNeighborsRegressor
 from metric_learn import MLKR
@@ -197,7 +198,7 @@ def load_hyperparams(hyper_cache: str):
 
 def training(
     Qrepresentation: str,
-    strs: List[Atoms],
+    strs: pd.Series,
     Y_train: np.ndarray,
     varsoutfile: Union[str, os.PathLike],
     no_metric=False,
@@ -205,6 +206,8 @@ def training(
 ):
 
     hyperparams = load_hyperparams(hyper_cache)
+    # Convert structures to list to avoid indexing issues
+    strs = strs.values
     ### REPRESENTATION CALCULATION ###
     repr_wall_start = time.perf_counter()
     repr_cpu_start = time.process_time()

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -36,8 +36,8 @@ def _generate_fchl19(strs: List[Atoms], rcut=8.0, acut=8.0, **kwargs) -> np.ndar
         X[i, :] = generate_representation(
             strs.iloc[i].get_atomic_numbers(),
             strs.iloc[i].get_positions(),
-            rcut=cutoff,
-            acut=cutoff,
+            rcut=rcut,
+            acut=acut,
         ).sum(axis=0)
     if np.isnan(X).any():
         raise ValueError("NaNs in FCHL representation!")

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -57,9 +57,13 @@ def _generate_fchl19(
     return X
 
 
-def _generate_mbdf(strs: Iterable[Atoms], cutoff: float = 8.0, **kwargs) -> np.ndarray:
+def _generate_mbdf(
+    strs: Iterable[Atoms], max_atoms=None, cutoff: float = 8.0, **kwargs
+) -> np.ndarray:
     from MBDF import generate_mbdf as generate_representation
 
+    if max_atoms is None:
+        max_atoms = max([len(s.get_atomic_numbers()) for s in strs])
     n = len(strs)
     ragged_atomic_numbers = np.empty(n, dtype=object)
     ragged_atomic_numbers[:] = [i.get_atomic_numbers() for i in strs]
@@ -71,6 +75,7 @@ def _generate_mbdf(strs: Iterable[Atoms], cutoff: float = 8.0, **kwargs) -> np.n
         cutoff_r=cutoff,
         normalized=False,
         local=False,
+        pad=max_atoms,
     )
     return X
 
@@ -958,7 +963,11 @@ def hyperopt(
                 Y_sorted = Y_fold[sorted_indices]
             sorted_Ys.append(Y_sorted)
 
-        print(f"JKML(k-NN): Precalculation done, took {time.perf_counter() - precalc_start:.1f} s.", flush=True)
+        print(
+            f"JKML(k-NN): Precalculation done, took {time.perf_counter() - precalc_start:.1f} s.",
+            flush=True,
+        )
+
         @skopt.utils.use_named_args(space)
         @lru_cache
         def objective(n_neighbors, weights, **repr_params):

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -313,12 +313,12 @@ def hyperopt(
     # hard-coded search spaces (for now)
     if Qrepresentation == "fchl":
         space = {
-            "rcut": skopt.space.Real((0.1, 20, "log-uniform")),
-            "acut": skopt.space.Real((0.1, 20, "log-uniform")),
+            "rcut": skopt.space.Real(0.1, 20, prior="log-uniform"),
+            "acut": skopt.space.Real(0.1, 20, prior="log-uniform"),
         }
     elif Qrepresentation == "mbdf":
         space = {
-            "cutoff": skopt.space.Real((0.1, 20, "log-uniform")),
+            "cutoff": skopt.space.Real(0.1, 20, prior="log-uniform"),
         }
     elif Qrepresentation == "mbtr":
         # these values are based on stuke2021efficient
@@ -335,7 +335,7 @@ def hyperopt(
     # TODO: add time print
 
     # add k-nn specific hyperparameter
-    space["n_neighbors"] = skopt.space.Integer((3, 15))
+    space["n_neighbors"] = skopt.space.Integer(3, 15)
     space["weights"] = skopt.space.Categorical(["uniform", "distance"])
 
     knn_param_names = ["n_neighbors", "weights"]

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -11,6 +11,13 @@ from typing import List, Tuple, Union, Dict
 import os
 from collections import defaultdict
 import time
+import warnings
+
+# ignore sklearn futurewarning
+warnings.filterwarnings(
+    "ignore",
+    "'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.",
+)
 
 
 def _generate_fchl19(strs: List[Atoms], cutoff: float = 8, **kwargs) -> np.ndarray:

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -8,11 +8,13 @@ import pickle
 from sklearn.neighbors import KNeighborsRegressor
 from metric_learn import MLKR
 from ase.atoms import Atoms
-from typing import Iterable, Tuple, Union, Dict
+from typing import Iterable, Tuple, Union, Dict, Literal, Callable, List, Optional
 import os
 from collections import defaultdict
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor, Future
+import heapq
 
 # ignore sklearn futurewarning
 warnings.filterwarnings(
@@ -264,6 +266,324 @@ def induced_kernel_distance(
     return D
 
 
+class VPTreeNode:
+    def __init__(self, idx: int, threshold: float, left=None, right=None):
+        self.idx = idx
+        self.threshold = threshold
+        self.left = left
+        self.right = right
+
+
+class VPTreeKNN:
+    def __init__(
+        self,
+        kernel_fun: Callable[[int, int, np.ndarray, np.ndarray], float],
+        n_neighbors: int = 5,
+        n_jobs: int = -1,
+        weights: Literal["uniform", "distance"] = "uniform",
+    ):
+        self.kernel = kernel_fun
+        self.k = n_neighbors
+        self.max_workers = (
+            os.environ.get("SLURM_CPUS_PER_TASK", os.cpu_count())
+            if n_jobs == -1
+            else n_jobs
+        )
+        self.weights = weights
+
+    def _build_vptree(
+        self,
+        indices: List[int],
+        dist_fn: Callable[[int, int], float],
+        executor: Optional[ThreadPoolExecutor] = None,
+        depth: int = 0,
+        max_parallel_depth: int = 4,
+    ) -> Optional[VPTreeNode]:
+        if not indices:
+            return None
+        if len(indices) == 1:
+            return VPTreeNode(idx=indices[0], threshold=0.0)
+
+        vp = indices[-1]
+        others = indices[:-1]
+        dists = [dist_fn(vp, i) for i in others]
+        median = float(np.median(np.array(dists)))
+
+        left = [i for i, d in zip(others, dists) if d <= median]
+        right = [i for i, d in zip(others, dists) if d > median]
+
+        if executor and depth < max_parallel_depth:
+            left_future: Future = executor.submit(
+                self._build_vptree,
+                left,
+                dist_fn,
+                executor,
+                depth + 1,
+                max_parallel_depth,
+            )
+            right_future: Future = executor.submit(
+                self._build_vptree,
+                right,
+                dist_fn,
+                executor,
+                depth + 1,
+                max_parallel_depth,
+            )
+            left_node = left_future.result()
+            right_node = right_future.result()
+        else:
+            left_node = self._build_vptree(
+                left, dist_fn, executor, depth + 1, max_parallel_depth
+            )
+            right_node = self._build_vptree(
+                right, dist_fn, executor, depth + 1, max_parallel_depth
+            )
+        return VPTreeNode(idx=vp, threshold=median, left=left_node, right=right_node)
+
+    def _search_vptree(
+        self,
+        node: VPTreeNode,
+        query_idx: int,
+        dist_fn: Callable[[int, int], float],
+        heap: List[Tuple[float, int]],
+    ):
+        if node is None:
+            return
+
+        d = dist_fn(query_idx, node.idx)
+        heapq.heappush(heap, (-d, node.idx))
+        if len(heap) > self.k:
+            heapq.heappop(heap)
+
+        if node.left is None and node.right is None:
+            return
+
+        if d < node.threshold:
+            near, far = node.left, node.right
+        else:
+            near, far = node.right, node.left
+
+        self._search_vptree(near, query_idx, dist_fn, heap)
+
+        # Prune using triangle inequality
+        if len(heap) < self.k or abs(d - node.threshold) < -heap[0][0]:
+            self._search_vptree(far, query_idx, dist_fn, heap)
+
+    def fit(
+        self,
+        X: np.ndarray,
+        Y: np.ndarray,
+    ):
+        """Build VP-tree on training data."""
+
+        def _train_dist_fn(i: int, j: int):
+            d_squared = (
+                self.kernel(i, i, X, X)
+                + self.kernel(j, j, X, X)
+                - 2 * self.kernel(i, j, X, X)
+            )
+            d_squared = np.maximum(d_squared, 0.0)
+            return np.sqrt(d_squared)
+
+        self.vp_tree = self._build_vptree(list(range(X.shape[0])), _train_dist_fn)
+        self.X_train = X
+        self.Y_train = Y
+
+    def k_neighbours(self, X: np.ndarray, k: int = None):
+        """Find closest k neighbors in the tree."""
+        if k is None:
+            k = self.k
+
+        def _test_dist_fn(i: int, j: int):
+            d_squared = (
+                self.kernel(i, i, X, X)
+                + self.kernel(j, j, self.X_train, self.X_train)
+                - 2 * self.kernel(i, j, X, self.X_train)
+            ).sum()
+            d_squared = np.maximum(d_squared, 0.0)
+            return np.sqrt(d_squared)
+
+        def _find_single(test_idx: int):
+            heap = []
+            self._search_vptree(self.vp_tree, test_idx, _test_dist_fn, heap, k=k)
+            neighbors = np.array([self.Y_train[idx] for (_, idx) in heap])
+            y = neighbors
+            d = np.array([-d for (d, _) in heap])
+            return y, d
+
+        m_test = X.shape[0]
+        if self.max_workers is not None:
+            with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+                y_d = list(executor.map(_find_single, range(m_test)))
+            ys = np.stack([x[0] for x in y_d])
+            D = np.stack([x[1] for x in y_d])
+        else:
+            ys = np.zeros((m_test, k))
+            D = np.zeros_like(ys)
+            for i in range(m_test):
+                y, d = _find_single(i)
+                ys[i, :] = y
+                D[i, :] = d
+        return ys, D
+
+    def predict(self, X: np.ndarray, k: int = None):
+        """Wrapper to replicate sklearn k-NN model behaviour."""
+        ys, D = self.k_neighbours(X, k)
+        if self.weights == "uniform":
+            return np.mean(ys, axis=1)
+        else:
+            w = 1 / D
+            return np.average(ys, weights=w, axis=1)
+
+
+def fast_kernel(
+    alchemy: str = "periodic-table",
+    alchemy_period_width: float = 1.6,
+    alchemy_group_width: float = 1.6,
+):
+
+    from qmllib.utils.alchemy import get_alchemy
+
+    doalchemy, pd = get_alchemy(
+        alchemy, emax=100, r_width=alchemy_group_width, c_width=alchemy_period_width
+    )
+    return lambda X, Y, k_args: get_local_kernels(
+        X, Y, doalchemy, pd, kernel_args=k_args
+    )
+
+
+def get_local_kernels(
+    A: np.ndarray,
+    B: np.ndarray,
+    doalchemy,
+    pd,
+    verbose: bool = False,
+    two_body_scaling: float = np.sqrt(8),
+    three_body_scaling: float = 1.6,
+    two_body_width: float = 0.2,
+    three_body_width: float = np.pi,
+    two_body_power: float = 4.0,
+    three_body_power: float = 2.0,
+    cut_start: float = 1.0,
+    cut_distance: float = 5.0,
+    fourier_order: int = 1,
+    kernel: str = "gaussian",
+    kernel_args: Optional[Dict[str, List[float]]] = None,
+) -> np.ndarray:
+    """Calculates the Gaussian kernel matrix K, where :math:`K_{ij}`:
+
+        :math:`K_{ij} = \\exp \\big( -\\frac{\\|A_i - B_j\\|_2^2}{2\\sigma^2} \\big)`
+
+    Where :math:`A_{i}` and :math:`B_{j}` are FCHL representation vectors.
+    K is calculated analytically using an OpenMP parallel Fortran routine.
+    Note, that this kernel will ONLY work with FCHL representations as input.
+
+    :param A: Array of FCHL representation - shape=(N, maxsize, 5, maxneighbors).
+    :type A: numpy array
+    :param B: Array of FCHL representation - shape=(M, maxsize, 5, maxneighbors).
+    :type B: numpy array
+
+    :param two_body_scaling: Weight for 2-body terms.
+    :type two_body_scaling: float
+    :param three_body_scaling: Weight for 3-body terms.
+    :type three_body_scaling: float
+
+    :param two_body_width: Gaussian width for 2-body terms
+    :type two_body_width: float
+    :param three_body_width: Gaussian width for 3-body terms.
+    :type three_body_width: float
+
+    :param two_body_power: Powerlaw for :math:`r^{-n}` 2-body terms.
+    :type two_body_power: float
+    :param three_body_power: Powerlaw for Axilrod-Teller-Muto 3-body term
+    :type three_body_power: float
+
+    :param cut_start: The fraction of the cut-off radius at which cut-off damping start.
+    :type cut_start: float
+    :param cut_distance: Cut-off radius. (default=5 angstrom)
+    :type cut_distance: float
+
+    :param fourier_order: 3-body Fourier-expansion truncation order.
+    :type fourier_order: integer
+    :param alchemy: Type of alchemical interpolation ``"periodic-table"`` or ``"off"`` are possible options. Disabling alchemical interpolation can yield dramatic speedups.
+    :type alchemy: string
+
+    :param alchemy_period_width: Gaussian width along periods (columns) in the periodic table.
+    :type alchemy_period_width: float
+    :param alchemy_group_width: Gaussian width along groups (rows) in the periodic table.
+    :type alchemy_group_width: float
+
+    :return: Array of FCHL kernel matrices matrix - shape=(n_sigmas, N, M),
+    :rtype: numpy array
+    """
+
+    from qmllib.representations.fchl.ffchl_module import fget_kernels_fchl
+    from qmllib.representations.fchl.fchl_kernel_functions import get_kernel_parameters
+
+    atoms_max = A.shape[1]
+    neighbors_max = A.shape[3]
+
+    if not B.shape[1] == atoms_max:
+        raise ValueError("Check FCHL representation sizes")
+    if not B.shape[3] == neighbors_max:
+        raise ValueError("Check FCHL representation sizes")
+
+    nm1 = A.shape[0]
+    nm2 = B.shape[0]
+
+    N1 = np.zeros((nm1), dtype=np.int32)
+    N2 = np.zeros((nm2), dtype=np.int32)
+
+    for a in range(nm1):
+        N1[a] = len(np.where(A[a, :, 1, 0] > 0.0001)[0])
+
+    for a in range(nm2):
+        N2[a] = len(np.where(B[a, :, 1, 0] > 0.0001)[0])
+
+    neighbors1 = np.zeros((nm1, atoms_max), dtype=np.int32)
+    neighbors2 = np.zeros((nm2, atoms_max), dtype=np.int32)
+
+    for a, representation in enumerate(A):
+        ni = N1[a]
+        for i, x in enumerate(representation[:ni]):
+            neighbors1[a, i] = len(np.where(x[0] < cut_distance)[0])
+
+    for a, representation in enumerate(B):
+        ni = N2[a]
+        for i, x in enumerate(representation[:ni]):
+            neighbors2[a, i] = len(np.where(x[0] < cut_distance)[0])
+
+    kernel_idx, kernel_parameters, n_kernels = get_kernel_parameters(
+        kernel, kernel_args
+    )
+
+    return fget_kernels_fchl(
+        A,
+        B,
+        verbose,
+        N1,
+        N2,
+        neighbors1,
+        neighbors2,
+        nm1,
+        nm2,
+        n_kernels,
+        three_body_width,
+        two_body_width,
+        cut_start,
+        cut_distance,
+        fourier_order,
+        pd,
+        two_body_scaling,
+        three_body_scaling,
+        doalchemy,
+        two_body_power,
+        three_body_power,
+        kernel_idx,
+        kernel_parameters,
+    )
+
+
 def load_hyperparams(hyper_cache: str):
     if hyper_cache is not None:
         with open(hyper_cache, "rb") as f:
@@ -307,12 +627,6 @@ def training(
     X_train = calculate_representation(
         Qrepresentation, strs, **hyperparams["representation"]
     )
-    if Qrepresentation == "fchl-kernel":
-        print("JKML(k-NN): Calculate train kernels.", flush=True)
-        K_train = calculate_kernel(
-            X_train, **(hyperparams["kernel"] if "kernel" in hyperparams else {})
-        )
-        D_train = induced_kernel_distance(K_train)
     repr_train_wall = time.perf_counter() - repr_wall_start
     repr_train_cpu = time.process_time() - repr_cpu_start
 
@@ -340,20 +654,22 @@ def training(
             algorithm="ball_tree",
             **hyperparams["knn"],
         )
-        knn.fit(X_train, Y_train)
     elif Qrepresentation == "fchl-kernel":
-        knn = KNeighborsRegressor(metric="precomputed", n_jobs=-1, **hyperparams["knn"])
-        knn.fit(D_train, Y_train)
+        kernel_fun = fast_kernel()
+
+        def kernel(i, j, X1, X2):
+            return kernel_fun(X1[None, i], X2[None, j], {"sigma": [1.0]})
+
+        print("JKML(Q-kNN): Learn VP-tree of kernel distances.")
+        knn = VPTreeKNN(kernel_fun=kernel, n_jobs=-1, **hyperparams["knn"])
     else:
         # "vanilla" k-NN
         knn = KNeighborsRegressor(n_jobs=-1, algorithm="auto", **hyperparams["knn"])
-        knn.fit(X_train, Y_train)
+
+    knn.fit(X_train, Y_train)
     train_wall = time.perf_counter() - train_wall_start
     train_cpu = time.process_time() - train_cpu_start
-    if Qrepresentation != "fchl-kernel":
-        n_train, d_train = X_train.shape
-    else:
-        n_train, d_train = X_train.shape[0], sum(X_train.shape[1:])
+    n_train, d_train = X_train.shape
     train_metadata = {
         "repr_train_wall": repr_train_wall,
         "repr_train_cpu": repr_train_cpu,
@@ -363,8 +679,6 @@ def training(
         "d_train": d_train,
     }
     print("JKML(Q-kNN): Training completed.", flush=True)
-    if Qrepresentation != "fchl-kernel":
-        K_train = None
     knn_params = knn.get_params()
     if not no_metric:
         knn_params["metric"] = "MLKR_placeholder"
@@ -378,8 +692,6 @@ def training(
                     X_train,
                     Y_train,
                     X_atoms,
-                    K_train,
-                    D_train,
                     knn_params,
                     train_metadata,
                 ],
@@ -405,7 +717,6 @@ def training(
         in [
             "X_train",
             "X_atoms",
-            "K_train",
             "A",
             "knn",
             "repr_train_wall",
@@ -423,7 +734,7 @@ def training(
 ###############################################################################
 
 
-def evaluate(Qrepresentation, X_train, strs, knn_model, K_train=None, hyper_cache=None):
+def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
 
     import numpy as np
 
@@ -442,9 +753,6 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, K_train=None, hyper_cach
     if Qrepresentation == "fchl-kernel":
         X_test, X_train = correct_fchl18_kernel_size(X_test, X_train)
         print("JKML(k-NN): Calculate test kernel(s).", flush=True)
-        K_test = calculate_kernel(X_test)
-        K = calculate_kernel(X_test, X_train)
-        D_test = induced_kernel_distance(K, K_train, K_test)
     repr_test_wall = time.perf_counter() - repr_wall_start
     repr_test_cpu = time.process_time() - repr_cpu_start
 
@@ -456,10 +764,7 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, K_train=None, hyper_cach
 
     test_wall_start = time.perf_counter()
     test_cpu_start = time.process_time()
-    if Qrepresentation == "fchl-kernel":
-        Y_predicted = knn_model.predict(D_test)
-    else:
-        Y_predicted = knn_model.predict(X_test)
+    Y_predicted = knn_model.predict(X_test)
     test_wall = time.perf_counter() - test_wall_start
     test_cpu = time.process_time() - test_cpu_start
     Y_predicted = Y_predicted[None, :]
@@ -520,11 +825,14 @@ def hyperopt(
         global X
         X = calculate_representation(Qrepresentation, strs)
         if Qrepresentation == "fchl-kernel":
-            K = calculate_kernel(X)
-            X = induced_kernel_distance(K)
+            kernel_fun = fast_kernel()
+
+            def kernel(i, j, X1, X2):
+                return kernel_fun(X1[None, i], X2[None, j], {"sigma": [1.0]})
 
     # add k-nn specific hyperparameters
-    space.append(skopt.space.Integer(3, 15, name="n_neighbors"))
+    max_k = 15
+    space.append(skopt.space.Integer(3, max_k, name="n_neighbors"))
     space.append(skopt.space.Categorical(["uniform", "distance"], name="weights"))
 
     knn_param_names = ["n_neighbors", "weights"]
@@ -571,6 +879,8 @@ def hyperopt(
         # could preallocate, but won't bother >:)
         distance_matrices = []
         sorted_Ys = []
+        if Qrepresentation == "fchl-kernel":
+            knns = []
         if not no_metric:
             mlkrs = []
 
@@ -579,6 +889,11 @@ def hyperopt(
             X_test = X[test_index]
             if no_metric:
                 D = pairwise_distances(X_test, X_fold, n_jobs=-1)
+            elif Qrepresentation == "fchl-kernel":
+                knn = VPTreeKNN(kernel, n_neighbors=15, weights="uniform")
+                knn.fit(X_fold, Y_fold)
+                # TODO: this maybe works
+                Y_fold, D = knn.k_neighbours(X_test, k=max_k)
             else:
                 mlkr = MLKR(n_components=50)
                 mlkr.fit(X_fold, Y_fold)
@@ -591,7 +906,12 @@ def hyperopt(
             D = np.take_along_axis(D, sorted_indices, axis=1)
             distance_matrices.append(D)
             # also store sorted y_train for prediction
-            Y_sorted = Y_fold[sorted_indices]
+            if Qrepresentation == "fchl-kernel":
+                # Y_fold is already made into a matrix; hence need to take along axis
+                Y_sorted = np.take_along_axis(Y_fold, indices=sorted_indices, axis=1)
+            else:
+                # Y_fold is still a vector; can index directly
+                Y_sorted = Y_fold[sorted_indices]
             sorted_Ys.append(Y_sorted)
 
         @skopt.utils.use_named_args(space)

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -307,18 +307,19 @@ def hyperopt(
 ):
 
     import skopt
+    from skopt.space import Real, Integer, Categorical
     from functools import lru_cache
     from sklearn.model_selection import cross_val_score
 
     # hard-coded search spaces (for now)
     if Qrepresentation == "fchl":
         space = {
-            "rcut": skopt.space.Real(0.1, 20, prior="log-uniform"),
-            "acut": skopt.space.Real(0.1, 20, prior="log-uniform"),
+            "rcut": Real(1.0, 20.0, prior="uniform"),
+            "acut": Real(1.0, 20.0, prior="uniform"),
         }
     elif Qrepresentation == "mbdf":
         space = {
-            "cutoff": skopt.space.Real(0.1, 20, prior="log-uniform"),
+            "cutoff": skopt.space.Real(1.0, 20.0, prior="uniform"),
         }
     elif Qrepresentation == "mbtr":
         # these values are based on stuke2021efficient

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -340,7 +340,6 @@ def hyperopt(
 
     knn_param_names = ["n_neighbors", "weights"]
 
-    @skopt.utils.use_named_args()
     @lru_cache
     def objective(**params):
         repr_params = {k: v for k, v in params.items() if k not in knn_param_names}

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -248,15 +248,25 @@ def training(
     train_wall = time.perf_counter() - train_wall_start
     train_cpu = time.process_time() - train_cpu_start
     n_train, d_train = X_train.shape
+    train_metadata = {
+        "repr_train_wall": repr_train_wall,
+        "repr_train_cpu": repr_train_cpu,
+        "train_wall": train_wall,
+        "train_cpu": train_cpu,
+        "n_train": n_train,
+        "d_train": d_train,
+    }
     print("JKML(Q-kNN): Training completed.", flush=True)
     knn_params = knn.get_params()
     knn_params["metric"] = "MLKR_placeholder"
     with open(varsoutfile, "wb") as f:
         print(f"JKML(Q-kNN): Saving training data to {varsoutfile}")
         if not no_metric:
-            pickle.dump([X_train, Y_train, X_atoms, A, mlkr, knn_params], f)
+            pickle.dump(
+                [X_train, Y_train, X_atoms, A, mlkr, knn_params, train_metadata], f
+            )
         else:
-            pickle.dump([X_train, Y_train, X_atoms, knn_params], f)
+            pickle.dump([X_train, Y_train, X_atoms, knn_params, train_metadata], f)
     return {
         key: value
         for key, value in locals().items()

--- a/JKML/src/QKNN.py
+++ b/JKML/src/QKNN.py
@@ -316,24 +316,25 @@ def evaluate(Qrepresentation, X_train, strs, knn_model, hyper_cache=None):
 
     ### CORRECTING THE FCHL MATRIX SIZES
     # IF YOU ARE EXTENDING THIS WILL MAKE THE MATRIXES OF THE SAME SIZE
-#    if Qrepresentation == "fchl":
-#        if X_train.shape[1] != X_test.shape[1]:
-#            if X_train.shape[1] > X_test.shape[1]:
-#                small = X_test
-#                large = X_train
-#            else:
-#                small = X_train
-#                large = X_test
-#            newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
-#            newmatrix[:, :, 0, :] = 1e100
-#            newmatrix[
-#                0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]
-#            ] = small
-#            if X_train.shape[1] > X_test.shape[1]:
-#                X_test = newmatrix
-#            else:
-#                X_train = newmatrix
-#
+    # THIS IS COMMENTED OUT AS IT DOES NOT APPLY TO FCHL'19 (global)
+    #    if Qrepresentation == "fchl":
+    #        if X_train.shape[1] != X_test.shape[1]:
+    #            if X_train.shape[1] > X_test.shape[1]:
+    #                small = X_test
+    #                large = X_train
+    #            else:
+    #                small = X_train
+    #                large = X_test
+    #            newmatrix = np.zeros([small.shape[0], large.shape[1], 5, large.shape[3]])
+    #            newmatrix[:, :, 0, :] = 1e100
+    #            newmatrix[
+    #                0 : small.shape[0], 0 : small.shape[1], 0:5, 0 : small.shape[3]
+    #            ] = small
+    #            if X_train.shape[1] > X_test.shape[1]:
+    #                X_test = newmatrix
+    #            else:
+    #                X_train = newmatrix
+    #
     ### THE EVALUATION
     test_wall_start = time.perf_counter()
     test_cpu_start = time.process_time()

--- a/JKML/src/QML.py
+++ b/JKML/src/QML.py
@@ -73,7 +73,7 @@ def training(
         )
 
     repr_train_wall = time.perf_counter() - repr_wall_start
-    repr_train_cpu = time.perf_counter() - repr_cpu_start
+    repr_train_cpu = time.process_time() - repr_cpu_start
     # some info about the full representation
     print(
         "JKML(QML): Shape of the training representation: " + str(X_train.shape),
@@ -141,7 +141,7 @@ def training(
             cho_solve(Ki, Y_train) for Ki in K
         ]  # calculates regression coeffitients
         train_wall = time.perf_counter() - train_wall_start
-        train_cpu = time.perf_counter() - train_cpu_start
+        train_cpu = time.process_time() - train_cpu_start
 
         # I will for now everytime save the trained QML
         f = open(varsoutfile, "wb")
@@ -164,7 +164,7 @@ def training(
         else:
             K = JKML_kernel(X_train_i, X_train_j, kernel_args={"sigma": sigmas})
         train_wall = time.perf_counter() - train_wall_start
-        train_cpu = time.perf_counter() - train_cpu_start
+        train_cpu = time.process_time() - train_cpu_start
         f = open(
             varsoutfile.split(".pkl")[0]
             + "_"
@@ -253,7 +253,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, sigmas, alpha, strs, Qkernel)
         )
 
     repr_test_wall = time.perf_counter() - repr_wall_start
-    repr_test_cpu = time.perf_counter() - repr_cpu_start
+    repr_test_cpu = time.process_time() - repr_cpu_start
     # some info about the full representation
     print(
         "JKML(QML): Shape of the testing representation: " + str(X_test.shape),
@@ -290,7 +290,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, sigmas, alpha, strs, Qkernel)
     Y_predicted = [np.dot(Ks[i], alpha[i]) for i in range(len(sigmas))]
 
     test_wall = time.perf_counter() - test_wall_start
-    test_cpu = time.perf_counter() - test_cpu_start
+    test_cpu = time.process_time() - test_cpu_start
     d_test = X_test.shape[1]
     return Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test
 

--- a/JKML/src/QML.py
+++ b/JKML/src/QML.py
@@ -74,6 +74,8 @@ def training(
 
     repr_train_wall = time.perf_counter() - repr_wall_start
     repr_train_cpu = time.process_time() - repr_cpu_start
+    n_train = X_train.shape[0]
+    d_train = np.sum(X_train.shape[1:])
     # some info about the full representation
     print(
         "JKML(QML): Shape of the training representation: " + str(X_train.shape),
@@ -123,8 +125,16 @@ def training(
         alpha = [cho_solve(K, Y_train)]
         train_wall = time.perf_counter() - train_wall_start
         train_cpu = time.perf_counter() - train_cpu_start
+        train_metadata = {
+            "repr_train_wall": repr_train_wall,
+            "repr_train_cpu": repr_train_cpu,
+            "train_wall": train_wall,
+            "train_cpu": train_cpu,
+            "n_train": n_train,
+            "d_train": d_train,
+        }
         f = open(varsoutfile, "wb")
-        pickle.dump([X_train, sigmas, alpha], f)
+        pickle.dump([X_train, sigmas, alpha, train_metadata], f)
         f.close()
         print("JKML(QML): Training completed.", flush=True)
     elif Qsplit == 1:
@@ -143,12 +153,20 @@ def training(
         train_wall = time.perf_counter() - train_wall_start
         train_cpu = time.process_time() - train_cpu_start
 
+        train_metadata = {
+            "repr_train_wall": repr_train_wall,
+            "repr_train_cpu": repr_train_cpu,
+            "train_wall": train_wall,
+            "train_cpu": train_cpu,
+            "n_train": n_train,
+            "d_train": d_train,
+        }
         # I will for now everytime save the trained QML
         f = open(varsoutfile, "wb")
         if Qrepresentation == "fchl":
-            pickle.dump([X_train, sigmas, alpha], f)
+            pickle.dump([X_train, sigmas, alpha, train_metadata], f)
         elif Qrepresentation == "mbdf":
-            pickle.dump([X_train, X_atoms, sigmas, alpha], f)
+            pickle.dump([X_train, X_atoms, sigmas, alpha, train_metadata], f)
         f.close()
         print("JKML(QML): Training completed.", flush=True)
     else:
@@ -165,6 +183,14 @@ def training(
             K = JKML_kernel(X_train_i, X_train_j, kernel_args={"sigma": sigmas})
         train_wall = time.perf_counter() - train_wall_start
         train_cpu = time.process_time() - train_cpu_start
+        train_metadata = {
+            "repr_train_wall": repr_train_wall,
+            "repr_train_cpu": repr_train_cpu,
+            "train_wall": train_wall,
+            "train_cpu": train_cpu,
+            "n_train": n_train,
+            "d_train": d_train,
+        }
         f = open(
             varsoutfile.split(".pkl")[0]
             + "_"
@@ -176,12 +202,10 @@ def training(
             + ".pkl",
             "wb",
         )
-        pickle.dump([K, Y_train], f)
+        pickle.dump([K, Y_train, train_metadata], f)
         f.close()
         alpha = None
         print("JKML(QML): Training completed.", flush=True)
-    n_train = X_train.shape[0]
-    d_train = np.sum(X_train.shape[1:])
 
     return {
         key: value

--- a/JKML/src/QML.py
+++ b/JKML/src/QML.py
@@ -180,7 +180,8 @@ def training(
         f.close()
         alpha = None
         print("JKML(QML): Training completed.", flush=True)
-    n_train, d_train = X_train.shape
+    n_train = X_train.shape[0]
+    d_train = np.sum(X_train.shape[1:])
 
     return {
         key: value
@@ -291,7 +292,7 @@ def evaluate(Qrepresentation, krr_cutoff, X_train, sigmas, alpha, strs, Qkernel)
 
     test_wall = time.perf_counter() - test_wall_start
     test_cpu = time.process_time() - test_cpu_start
-    d_test = X_test.shape[1]
+    d_test = np.sum(X_test.shape[1:])
     return Y_predicted, repr_test_wall, repr_test_cpu, test_wall, test_cpu, d_test
 
 

--- a/JKML/src/arguments.py
+++ b/JKML/src/arguments.py
@@ -365,6 +365,9 @@ def arguments(argument_list=[]):
     md_steps = 2000
     md_dump = 1
 
+    # hyperparams
+    Qhyper = False
+
     # Output files
     outfile = "predicted.pkl"
     varsoutfile = "model.pkl"
@@ -1043,6 +1046,13 @@ def arguments(argument_list=[]):
         if arg == "-mbdf":
             Qmethod = "krr"
             Qrepresentation = "mbdf"
+            continue
+
+        # Hyperparameter optimisation
+        if arg == "-hyper":
+            Qhyper = True
+            Qtrain = 0  # set Qtrain to zero, as the "training" be part of the tuning
+            Qeval = 0  # similarly as above
             continue
 
         # Unknown argument

--- a/JKML/src/arguments.py
+++ b/JKML/src/arguments.py
@@ -367,6 +367,7 @@ def arguments(argument_list=[]):
 
     # hyperparams
     Qhyper = False
+    hyper_cache = None
 
     # Output files
     outfile = "predicted.pkl"
@@ -1053,6 +1054,15 @@ def arguments(argument_list=[]):
             Qhyper = True
             Qtrain = 0  # set Qtrain to zero, as the "training" be part of the tuning
             Qeval = 0  # similarly as above
+            continue
+
+        # Load hyperparameter cache
+        if last == "-hyper-cache":
+            hyper_cache = arg
+            last = ""
+            continue
+        if arg == "-hyper-cache":
+            last = arg
             continue
 
         # Unknown argument

--- a/JKML/src/arguments.py
+++ b/JKML/src/arguments.py
@@ -761,12 +761,13 @@ def arguments(argument_list=[]):
             continue
         if last == "-repr":
             Qrepresentation = arg
-            last == ""
+            last = ""
             continue
 
         # turn off metric learning for k-NN
-        if arg == "-no-metric":
+        if arg == "-nometric":
             no_metric = True
+            continue
 
         # Epochs
         if arg == "-nn_epochs" or arg == "-epochs":

--- a/JKML/src/arguments.py
+++ b/JKML/src/arguments.py
@@ -761,6 +761,7 @@ def arguments(argument_list=[]):
             continue
         if last == "-repr":
             Qrepresentation = arg
+            last == ""
             continue
 
         # turn off metric learning for k-NN

--- a/JKML/src/arguments.py
+++ b/JKML/src/arguments.py
@@ -330,6 +330,9 @@ def arguments(argument_list=[]):
     Qmethod = "krr"
     Qrepresentation = "fchl"
 
+    # knn default
+    no_metric = False
+
     # Predefined QML
     Qkernel = "Gaussian"
     sigmas = [1.0]

--- a/JKML/src/fortran/__init__.py
+++ b/JKML/src/fortran/__init__.py
@@ -1,0 +1,1 @@
+# from . import ffchl_vp_tree #noqa:F403

--- a/JKML/src/fortran/fchl_vp_tree.f90
+++ b/JKML/src/fortran/fchl_vp_tree.f90
@@ -1,0 +1,550 @@
+module vp_tree
+   use kernel_distance
+   use omp_lib
+   implicit none
+
+   ! flag for having test data
+   logical :: has_test = .false.
+   ! training indices, left and right children arrays
+   integer, allocatable :: vp_index(:)
+   integer, allocatable :: vp_left(:)
+   integer, allocatable :: vp_right(:)
+   ! threshold array
+   double precision, allocatable :: vp_threshold(:)
+   integer :: vp_next = 1
+
+   ! train, test data
+   double precision, allocatable :: X_train(:,:,:,:), Y_train(:), X_test(:,:,:,:)
+contains
+
+   subroutine init_tree(max_nodes)
+      implicit none
+      integer, intent(in) :: max_nodes
+
+      ! clean up old
+      if (allocated(vp_index)) deallocate(vp_index)
+      if (allocated(vp_left)) deallocate(vp_left)
+      if (allocated(vp_right)) deallocate(vp_right)
+      if (allocated(vp_threshold)) deallocate(vp_threshold)
+
+      allocate(vp_index(max_nodes))
+      allocate(vp_left(max_nodes))
+      allocate(vp_right(max_nodes))
+      allocate(vp_threshold(max_nodes))
+
+      vp_next = 1
+   end subroutine init_tree
+
+   subroutine clean_training_data()
+      if (allocated(X_train)) deallocate(X_train)
+      if (allocated(Y_train)) deallocate(Y_train)
+      if (allocated(vp_index)) deallocate(vp_index)
+      if (allocated(vp_left)) deallocate(vp_left)
+      if (allocated(vp_right)) deallocate(vp_right)
+      if (allocated(vp_threshold)) deallocate(vp_threshold)
+
+   end subroutine clean_training_data
+
+   subroutine load(X_in, Y_in, vp_index_in, vp_left_in, vp_right_in, vp_threshold_in, verbose_in, n1, nneigh1_in, nm1, nsigmas_in, &
+   & t_width_in, d_width_in, cut_start_in, cut_distance_in, order_in, pd_in, &
+   & distance_scale_in, angular_scale_in, alchemy_in, two_body_power_in, three_body_power_in, &
+   & kernel_idx_in, parameters_in, root_id)
+      ! raw input data
+      double precision, intent(in) :: X_in(:,:, :, :), Y_in(:)
+
+      ! previously learned VP params
+      integer, intent(in) :: vp_index_in(:), vp_left_in(:), vp_right_in(:)
+      double precision, intent(in) :: vp_threshold_in(:)
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose_in
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: n1 ! save
+
+      ! Number of molecules
+      integer, intent(in) :: nm1 ! save
+
+      ! Number of sigmas
+      integer, intent(in) :: nsigmas_in ! save
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh1_in ! save
+
+      ! Angular Gaussian width
+      double precision, intent(in) :: t_width_in ! save
+
+      ! Distance Gaussian width
+      double precision, intent(in) :: d_width_in ! save
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start_in ! save
+      double precision, intent(in) :: cut_distance_in ! save
+
+      ! Truncation order for Fourier terms
+      integer, intent(in) :: order_in ! save
+
+      ! Periodic table distance matrix
+      double precision, dimension(:, :), intent(in) :: pd_in ! save
+
+      ! Scaling for angular and distance terms
+      double precision, intent(in) :: distance_scale_in ! save
+      double precision, intent(in) :: angular_scale_in ! save
+
+      ! Switch alchemy on or off
+      logical, intent(in) :: alchemy_in ! save
+
+      ! Decaying power laws for two- and three-body terms
+      double precision, intent(in) :: two_body_power_in ! save
+      double precision, intent(in) :: three_body_power_in ! save
+
+      ! Kernel ID and corresponding parameters
+      integer, intent(in) :: kernel_idx_in ! save
+      double precision, dimension(:, :), intent(in) :: parameters_in ! save
+      integer, intent(out) :: root_id
+
+      integer :: n_train, i
+      integer, allocatable :: indices(:)
+
+      ! openmp parameters
+      integer :: nthreads, max_depth
+
+      ! clean up training data (if already allocated)
+      call clean_training_data()
+      allocate(X_train(size(X_in,1), size(X_in,2), size(X_in,3), size(X_in,4)))
+      X_train = X_in
+      allocate(Y_train(size(Y_in,1)))
+      Y_train = Y_in
+      ! get size of X_train
+      n_train = size(X_train, 1)
+
+      ! initialize vp-tree
+      call init_tree(n_train)
+      ! copy learned vp tree parameters to collections
+      vp_index = vp_index_in
+      vp_left = vp_left_in
+      vp_right = vp_right_in
+      vp_threshold = vp_threshold_in
+
+      ! initialise kernel
+      call init_train(X_train, verbose_in, n1, nneigh1_in, nm1, nsigmas_in, t_width_in, &
+      & d_width_in, cut_start_in, cut_distance_in, order_in, pd_in, distance_scale_in, &
+      & angular_scale_in, alchemy_in, two_body_power_in, three_body_power_in, kernel_idx_in, &
+      & parameters_in)
+
+   end subroutine load
+
+   subroutine train(X_in, Y_in, verbose_in, n1, nneigh1_in, nm1, nsigmas_in, &
+   & t_width_in, d_width_in, cut_start_in, cut_distance_in, order_in, pd_in, &
+   & distance_scale_in, angular_scale_in, alchemy_in, two_body_power_in, three_body_power_in, &
+   & kernel_idx_in, parameters_in, root_id)
+
+      double precision, intent(in) :: X_in(:,:, :, :), Y_in(:)
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose_in
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: n1 ! save
+
+      ! Number of molecules
+      integer, intent(in) :: nm1 ! save
+
+      ! Number of sigmas
+      integer, intent(in) :: nsigmas_in ! save
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh1_in ! save
+
+      ! Angular Gaussian width
+      double precision, intent(in) :: t_width_in ! save
+
+      ! Distance Gaussian width
+      double precision, intent(in) :: d_width_in ! save
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start_in ! save
+      double precision, intent(in) :: cut_distance_in ! save
+
+      ! Truncation order for Fourier terms
+      integer, intent(in) :: order_in ! save
+
+      ! Periodic table distance matrix
+      double precision, dimension(:, :), intent(in) :: pd_in ! save
+
+      ! Scaling for angular and distance terms
+      double precision, intent(in) :: distance_scale_in ! save
+      double precision, intent(in) :: angular_scale_in ! save
+
+      ! Switch alchemy on or off
+      logical, intent(in) :: alchemy_in ! save
+
+      ! Decaying power laws for two- and three-body terms
+      double precision, intent(in) :: two_body_power_in ! save
+      double precision, intent(in) :: three_body_power_in ! save
+
+      ! Kernel ID and corresponding parameters
+      integer, intent(in) :: kernel_idx_in ! save
+      double precision, dimension(:, :), intent(in) :: parameters_in ! save
+      integer, intent(out) :: root_id
+
+      integer :: n_train, i
+      integer, allocatable :: indices(:)
+
+      ! openmp parameters
+      integer :: nthreads, max_depth
+
+      ! clean up training data (if already allocated)
+      call clean_training_data()
+      allocate(X_train(size(X_in,1), size(X_in,2), size(X_in,3), size(X_in,4)))
+      X_train = X_in
+      allocate(Y_train(size(Y_in,1)))
+      Y_train = Y_in
+      ! get size of X_train
+      n_train = size(X_train, 1)
+
+      ! initialize vp-tree
+      call init_tree(n_train)
+
+      ! initialise kernel
+      call init_train(X_train, verbose_in, n1, nneigh1_in, nm1, nsigmas_in, t_width_in, &
+      & d_width_in, cut_start_in, cut_distance_in, order_in, pd_in, distance_scale_in, &
+      & angular_scale_in, alchemy_in, two_body_power_in, three_body_power_in, kernel_idx_in, &
+      & parameters_in)
+
+      allocate(indices(n_train))
+      do i = 1, n_train
+         indices(i) = i
+      end do
+
+      ! set up multithreading parameters
+      nthreads = omp_get_num_threads()
+      ! max_depth = log2(nthreads) + 1 as the tree always splits into at most 2 branches
+      max_depth = int(log(real(nthreads))/log(2.0d0)) + 1
+      call build_vptree(indices, n_train, 0, max_depth, root_id)
+
+      deallocate(indices)
+   end subroutine train
+
+   recursive subroutine build_vptree(indices, n, depth, max_parallel_depth, node_id)
+      implicit none
+      integer, intent(in) :: indices(n)
+      integer, intent(in) :: n
+      integer, intent(in) :: depth, max_parallel_depth
+      integer, intent(out) :: node_id
+
+      integer :: i, left_id, right_id
+      double precision, allocatable :: dists(:)
+      integer, allocatable :: left_set(:), right_set(:)
+      integer :: count_left, count_right
+      double precision :: median
+
+      if (n == 0) then
+         node_id = -1
+         return
+      end if
+
+      ! Ensure only one thread updates vp_next at a time
+      !$omp atomic capture
+      node_id = vp_next
+      vp_next = vp_next + 1
+      !$omp end atomic
+
+      vp_index(node_id) = indices(n)  ! choose last as vantage point
+
+      if (n == 1) then
+         vp_threshold(node_id) = 0.0
+         vp_left(node_id) = -1
+         vp_right(node_id) = -1
+         return
+      end if
+
+      allocate(dists(n-1))
+      do i = 1, n-1
+         dists(i) = train_distance(indices(i), indices(n))  ! dist to vantage point
+      end do
+
+      median = quick_median(dists)
+
+      allocate(left_set(n-1), right_set(n-1))
+      count_left = 0
+      count_right = 0
+      do i = 1, n-1
+         if (dists(i) <= median) then
+            count_left = count_left + 1
+            left_set(count_left) = indices(i)
+         else
+            count_right = count_right + 1
+            right_set(count_right) = indices(i)
+         end if
+      end do
+
+      vp_threshold(node_id) = median
+
+      if (depth < max_parallel_depth) then
+         !$omp parallel sections default(shared)
+         !$omp section
+         call build_vptree(left_set(1:count_left), count_left, depth+1, max_parallel_depth, left_id)
+         !$omp section
+         call build_vptree(right_set(1:count_right), count_right, depth+1, max_parallel_depth, right_id)
+         !$omp end parallel sections
+      else
+         call build_vptree(left_set(1:count_left), count_left, depth+1, max_parallel_depth, left_id)
+         call build_vptree(right_set(1:count_right), count_right, depth+1, max_parallel_depth, right_id)
+      end if
+
+      vp_left(node_id) = left_id
+      vp_right(node_id) = right_id
+
+      deallocate(dists, left_set, right_set)
+   end subroutine build_vptree
+
+
+   subroutine search_vp_tree(i, k, neighbors, distances, return_distances)
+      integer, intent(in) :: i, k
+      integer, intent(out) :: neighbors(k)
+      double precision, optional, intent(out) :: distances(k)
+      logical, optional, intent(in) :: return_distances
+
+      logical :: ret_dists
+      integer, allocatable :: heap_idx(:)
+      double precision, allocatable :: heap_dist(:)
+      integer :: heap_size, j
+
+      ret_dists = .false.
+      if (present(return_distances)) ret_dists = return_distances
+      allocate(heap_idx(k))
+      allocate(heap_dist(k))
+      heap_size = 0
+
+      call search_node(1, i, k, heap_idx, heap_dist, heap_size)
+
+      neighbors = heap_idx
+
+      if (ret_dists) distances = heap_dist
+
+      deallocate(heap_idx, heap_dist)
+   end subroutine search_vp_tree
+
+   subroutine set_up_test(X_test_in, n2, nneigh2_in, nm2)
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: n2 ! save
+
+      ! Number of molecules
+      integer, intent(in) :: nm2 ! save
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh2_in ! save
+
+      double precision, intent(in) :: X_test_in(:,:,:,:)
+
+      ! free previous X_test
+      if (allocated(X_test)) then
+         deallocate(X_test)
+      end if
+      allocate(X_test(size(X_test_in,1),size(X_test_in,2),size(X_test_in,3),size(X_test_in,4)))
+      X_test = X_test_in
+      has_test = .true.
+      call init_test(X_test, n2, nneigh2_in, nm2)
+
+   end subroutine set_up_test
+
+   subroutine predict(k, n_test, Y_pred, weight_by_distance)
+      integer, intent(in) :: k, n_test
+      double precision, dimension(n_test), intent(out) :: Y_pred
+      logical, optional, intent(in) :: weight_by_distance
+
+      integer :: i, j
+      integer, allocatable :: neighbors(:,:)
+      double precision, allocatable :: distances(:,:)
+      double precision :: sum, weight_sum, w
+      logical :: use_weights
+
+      if (.not. has_test) then
+         print *, "Test data has not been provided! Call set_up_test first!"
+         stop
+      end if
+      use_weights = .false.
+      if (present(weight_by_distance)) use_weights = weight_by_distance
+
+      allocate(neighbors(k,n_test))
+
+      if (use_weights) then
+         allocate(distances(k,n_test))
+         call kneighbors(k, n_test, neighbors,.true.,distances)
+      else
+         call kneighbors(k, n_test, neighbors)
+      end if
+      do i = 1, n_test
+         sum = 0.0d0
+         if (use_weights) then
+            weight_sum = 0.0d0
+            do j = 1, k
+               w = 1.0d0 / max(distances(j,i), 1.0d-12) ! avoid div-by-0
+               sum = sum + w * Y_train(neighbors(j, i))
+               weight_sum = weight_sum + w
+            end do
+            Y_pred(i) = sum / weight_sum
+         else
+            do j = 1, k
+               sum = sum + Y_train(neighbors(j, i))
+            end do
+            Y_pred(i) = sum / k
+         end if
+      end do
+
+      deallocate(neighbors)
+      if (use_weights) deallocate(distances)
+
+   end subroutine predict
+
+   subroutine kneighbors(k, n_test, neighbor_indices, return_distances, neighbor_distances)
+      integer, intent(in) :: k, n_test
+      integer, dimension(k,n_test), intent(out) :: neighbor_indices
+      logical, intent(in), optional :: return_distances
+      double precision, intent(out), optional, dimension(k,n_test) :: neighbor_distances
+
+      integer :: i
+
+      logical :: do_return_distances
+
+      if (.not. has_test) then
+         print *, "Test data has not been provided! Call set_up_test first!"
+         stop
+      end if
+
+      do_return_distances = .false.
+      if (present(return_distances)) do_return_distances = return_distances
+
+      !$omp parallel do default(shared) private(i)
+      do i = 1, n_test
+         if (do_return_distances) then
+            call search_vp_tree(i, k, neighbor_indices(:, i), neighbor_distances(:, i), do_return_distances)
+         else
+            call search_vp_tree(i, k, neighbor_indices(:, i))
+         end if
+      end do
+      !$omp end parallel do
+   end subroutine kneighbors
+
+   recursive subroutine search_node(node, test_idx, k, heap_idx, heap_dist, heap_size)
+      integer, intent(in) :: node, test_idx, k
+      integer, intent(inout) :: heap_idx(:), heap_size
+      double precision, intent(inout) :: heap_dist(:)
+
+      integer :: tr_idx, left, right
+      double precision :: d, diff, threshold
+      integer :: i, worst_idx
+      double precision :: worst_dist
+
+      if (node == -1) return
+
+      tr_idx = vp_index(node)
+      d = test_distance(test_idx, tr_idx)
+
+      ! Insert into heap (brute force k-NN buffer)
+      if (heap_size < k) then
+         heap_size = heap_size + 1
+         heap_idx(heap_size) = tr_idx
+         heap_dist(heap_size) = d
+      else
+         worst_idx = 1
+         worst_dist = heap_dist(1)
+         do i = 2, k
+            if (heap_dist(i) > worst_dist) then
+               worst_idx = i
+               worst_dist = heap_dist(i)
+            end if
+         end do
+         if (d < worst_dist) then
+            heap_dist(worst_idx) = d
+            heap_idx(worst_idx) = tr_idx
+         end if
+      end if
+
+      threshold = vp_threshold(node)
+      diff = d - threshold
+      left = vp_left(node)
+      right = vp_right(node)
+
+      if (diff < 0) then
+         call search_node(left, test_idx, k, heap_idx, heap_dist, heap_size)
+         if (abs(diff) < maxval(heap_dist(1:heap_size))) then
+            call search_node(right, test_idx, k, heap_idx, heap_dist, heap_size)
+         end if
+      else
+         call search_node(right, test_idx, k, heap_idx, heap_dist, heap_size)
+         if (abs(diff) < maxval(heap_dist(1:heap_size))) then
+            call search_node(left, test_idx, k, heap_idx, heap_dist, heap_size)
+         end if
+      end if
+   end subroutine search_node
+
+   recursive function quickselect(arr, left, right, k) result(pivot)
+      double precision, intent(inout) :: arr(:)
+      integer, intent(in) :: left, right, k
+      double precision :: pivot
+      integer :: pivot_index, i, j
+      double precision :: temp, pivot_value
+
+      if (left == right) then
+         pivot = arr(left)
+         return
+      end if
+
+      ! Deterministic pivot: middle element
+      pivot_index = (left + right) / 2
+      pivot_value = arr(pivot_index)
+
+      ! Swap pivot to end
+      temp = arr(pivot_index)
+      arr(pivot_index) = arr(right)
+      arr(right) = temp
+
+      ! Partition
+      j = left
+      do i = left, right - 1
+         if (arr(i) < pivot_value) then
+            temp = arr(i)
+            arr(i) = arr(j)
+            arr(j) = temp
+            j = j + 1
+         end if
+      end do
+
+      ! Move pivot to final position
+      temp = arr(j)
+      arr(j) = arr(right)
+      arr(right) = temp
+
+      ! Recursive selection
+      if (k == j) then
+         pivot = arr(j)
+      else if (k < j) then
+         pivot = quickselect(arr, left, j - 1, k)
+      else
+         pivot = quickselect(arr, j + 1, right, k)
+      end if
+   end function quickselect
+
+   function quick_median(arr) result(median)
+      double precision, intent(in) :: arr(:)
+      double precision :: median
+      double precision, allocatable :: temp(:)
+      integer :: n, mid
+
+      n = size(arr)
+      allocate(temp(n))
+      temp = arr
+
+      mid = (n + 1) / 2
+
+      if (mod(n, 2) == 0) then
+         median = 0.5 * (quickselect(temp, 1, n, mid) + quickselect(temp, 1, n, mid + 1))
+      else
+         median = quickselect(temp, 1, n, mid)
+      end if
+
+      deallocate(temp)
+   end function quick_median
+
+end module vp_tree

--- a/JKML/src/fortran/ffchl_kernel_distance.f90
+++ b/JKML/src/fortran/ffchl_kernel_distance.f90
@@ -1,0 +1,442 @@
+module kernel_distance
+   use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
+
+   use ffchl_kernels, only: kernel
+   implicit none
+
+   private
+   ! use target to declare as pointer-able (to avoid copying x1 and x2 a million times)
+   !f2py intent(out) :: x1, x2
+   double precision, dimension(:, :, :, :), allocatable :: X_tr, X_te
+   ! Number of molecules
+   integer :: num_molecules1, num_molecules2
+   ! List of numbers of atoms in each molecule/cluster
+   integer, dimension(:), allocatable :: num_atoms1, num_atoms2
+   integer :: maxatoms1, maxatoms2
+   ! Number of sigmas
+   integer :: nsigmas ! save
+   ! Number of neighbors
+   integer, dimension(:, :), allocatable :: nneigh1, nneigh2
+   ! Max neighbors
+   integer :: maxneigh1, maxneigh2
+   double precision :: t_width, d_width, ang_norm2
+   ! Max index in the periodic table
+   integer :: pmax1 ! can precalculate
+   integer :: pmax2 ! can precalculate
+
+   ! Fraction of cut_distance at which cut-off starts
+   double precision :: cut_start, cut_distance
+   ! Truncation order for Fourier terms
+   integer :: order
+   ! Periodic table distance matrix
+   double precision, dimension(:, :), allocatable :: pd
+   ! Scaling for angular and distance terms
+   double precision :: distance_scale, angular_scale
+
+   ! Switch alchemy on or off
+   logical :: alchemy
+   ! Decaying power laws for two- and three-body terms
+   double precision :: two_body_power ! save
+   double precision :: three_body_power ! save
+
+   ! Kernel ID and corresponding parameters
+   integer:: kernel_idx ! save
+   double precision, dimension(:, :), allocatable :: parameters ! save
+
+   logical :: verbose
+   public :: init_train, init_test
+   public :: train_kernel_element, test_kernel_element, test_train_kernel_element, test_distance, train_distance
+   private :: X_tr, X_te
+   private :: kernel_element
+
+contains
+
+   subroutine clean_train()
+      ! clean up training data if it exists to avoid double alloc
+      if (allocated(X_tr)) deallocate(X_tr)
+      if (allocated(num_atoms1)) deallocate(num_atoms1)
+      if (allocated(nneigh1)) deallocate(nneigh1)
+      if (allocated(pd)) deallocate(pd)
+      if (allocated(parameters)) deallocate(parameters)
+   end subroutine clean_train
+
+   subroutine init_train(x_in1, verbose_in, n1, nneigh1_in, nm1, nsigmas_in, &
+   & t_width_in, d_width_in, cut_start_in, cut_distance_in, order_in, pd_in, &
+   & distance_scale_in, angular_scale_in, alchemy_in, two_body_power_in, three_body_power_in, &
+   & kernel_idx_in, parameters_in)
+      ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x_in1 ! can be saved
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose_in
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: n1 ! save
+
+      ! Number of molecules
+      integer, intent(in) :: nm1 ! save
+
+      ! Number of sigmas
+      integer, intent(in) :: nsigmas_in ! save
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh1_in ! save
+
+      ! Angular Gaussian width
+      double precision, intent(in) :: t_width_in ! save
+
+      ! Distance Gaussian width
+      double precision, intent(in) :: d_width_in ! save
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start_in ! save
+      double precision, intent(in) :: cut_distance_in ! save
+
+      ! Truncation order for Fourier terms
+      integer, intent(in) :: order_in ! save
+
+      ! Periodic table distance matrix
+      double precision, dimension(:, :), intent(in) :: pd_in ! save
+
+      ! Scaling for angular and distance terms
+      double precision, intent(in) :: distance_scale_in ! save
+      double precision, intent(in) :: angular_scale_in ! save
+
+      ! Switch alchemy on or off
+      logical, intent(in) :: alchemy_in ! save
+
+      ! Decaying power laws for two- and three-body terms
+      double precision, intent(in) :: two_body_power_in ! save
+      double precision, intent(in) :: three_body_power_in ! save
+
+      ! Kernel ID and corresponding parameters
+      integer, intent(in) :: kernel_idx_in ! save
+      double precision, dimension(:, :), intent(in) :: parameters_in ! save
+
+      ! clean up old data
+      call clean_train()
+      ! allocate raw datas
+      allocate(X_tr(size(x_in1,1), size(x_in1,2), size(x_in1,3), size(x_in1,4)))
+      X_tr = x_in1
+
+      ! save sigmas
+      nsigmas = nsigmas_in
+      ! allocate atom number lists
+      allocate(num_atoms1(size(n1,1)))
+      num_atoms1 = n1
+
+      maxatoms1 = maxval(n1)
+
+      num_molecules1 = nm1
+
+      ! allocate neighbour number lists
+      allocate(nneigh1(size(nneigh1_in,1),size(nneigh1_in,2)))
+      nneigh1 = nneigh1_in
+
+
+      ! Get max number of neighbors
+      maxneigh1 = maxval(nneigh1)
+
+      t_width = t_width_in
+      d_width = d_width_in
+      ! Calculate angular normalization constant
+      ang_norm2 = get_angular_norm2(t_width)
+
+      ! pmax = max nuclear charge
+      pmax1 = get_pmax(X_tr, n1)
+
+      cut_start = cut_start_in
+      cut_distance = cut_distance_in
+
+      order = order_in
+
+      allocate(pd(size(pd_in,1), size(pd_in,2)))
+      pd = pd_in
+
+      distance_scale = distance_scale_in
+      angular_scale = angular_scale_in
+
+      alchemy = alchemy_in
+
+      two_body_power = two_body_power_in
+      three_body_power = three_body_power_in
+
+      kernel_idx = kernel_idx_in
+
+      allocate(parameters(size(parameters_in,1),size(parameters_in,2)))
+      parameters = parameters_in
+
+      verbose = verbose_in
+   end subroutine init_train
+
+   subroutine clean_test()
+      ! deallocate everything related to X_test
+      if (allocated(X_te)) then
+         deallocate(X_te)
+      end if
+      if (allocated(num_atoms2)) then
+         deallocate(num_atoms2)
+      end if
+      if (allocated(nneigh2)) then
+         deallocate(nneigh2)
+      end if
+
+
+   end subroutine clean_test
+
+   subroutine init_test(x_in2, n2, nneigh2_in, nm2)
+      ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x_in2 ! can be saved
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: n2 ! save
+
+      ! Number of molecules
+      integer, intent(in) :: nm2 ! save
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh2_in ! save
+
+      ! clean up previously allocated values
+      call clean_test()
+      ! allocate raw datas
+      allocate(X_te(size(x_in2,1), size(x_in2,2), size(x_in2,3), size(x_in2,4)))
+      X_te = x_in2
+
+      ! allocate atom number lists
+      allocate(num_atoms2(size(n2,1)))
+      num_atoms2 = n2
+
+      maxatoms2 = maxval(n2)
+
+      num_molecules2 = nm2
+
+      ! allocate neighbour number lists
+      allocate(nneigh2(size(nneigh2_in,1),size(nneigh2_in,2)))
+      nneigh2 = nneigh2_in
+
+      pmax2 = get_pmax(X_te, n2)
+
+      ! Get max number of neighbors
+      maxneigh2 = maxval(nneigh2)
+
+   end subroutine init_test
+
+   double precision function kernel_element(i, j, mode)
+
+      ! Internal counters
+      character(len=*), intent(in) :: mode
+      integer, intent(in) :: i, j
+      integer :: ii, jj
+
+      ! Temporary variables necessary for parallelization
+      double precision :: s12
+
+      ! Pre-computed terms in the full distance matrix
+      double precision, allocatable, dimension(:, :) :: self_scalar1 ! calculate on-the-fly
+      double precision, allocatable, dimension(:, :) :: self_scalar2 ! calculate on-the-fly
+
+      ! Pre-computed two-body weights
+      double precision, allocatable, dimension(:, :, :) :: ksi1 ! calculate on-the-fly
+      double precision, allocatable, dimension(:, :, :) :: ksi2 ! calculate on-the-fly
+
+      ! Pre-computed terms for the Fourier expansion of the three-body term
+      double precision, allocatable, dimension(:, :, :, :, :) :: sinp1 ! otf
+      double precision, allocatable, dimension(:, :, :, :, :) :: sinp2 ! otf
+      double precision, allocatable, dimension(:, :, :, :, :) :: cosp1 ! otf
+      double precision, allocatable, dimension(:, :, :, :, :) :: cosp2 ! otf
+
+      ! single elements from x1, x2
+      double precision, dimension(:, :, :, :), allocatable :: v1
+      double precision, dimension(:, :, :, :), allocatable :: v2
+
+      integer :: n1(1)
+      integer :: n2(1)
+      integer, dimension(:, :), allocatable :: nneigh1_i
+      integer, dimension(:, :), allocatable :: nneigh2_j
+      integer :: mneigh1, mneigh2, pm1, pm2
+
+      ! Work kernel space
+      integer :: n
+      double precision, allocatable, dimension(:) :: ktmp
+      double precision, allocatable, dimension(:) :: kernels
+
+      ! copy relevant elements to the pointers
+      select case (trim(mode))
+       case ("train")
+         ! train x train kernel
+         allocate(v1(1,size(X_tr,2),5,size(X_tr,4)))
+         allocate(v2(1,size(X_tr,2),5,size(X_tr,4)))
+         v1(1,:,:,:) = X_tr(i, :, :, :)
+         v2(1,:,:,:) = X_tr(j, :, :, :)
+         n1 = [num_atoms1(i)]
+         n2 = [num_atoms1(j)]
+         nneigh1_i = reshape(nneigh1(i, :), [1, size(nneigh1, 2)])
+         nneigh2_j = reshape(nneigh1(j, :), [1, size(nneigh1, 2)])
+         mneigh1 = maxval(nneigh1_i)
+         mneigh2 = maxval(nneigh2_j)
+         pm1 = pmax1
+         pm2 = pmax1
+         allocate (ksi1(1, num_atoms1(i), mneigh1))
+         allocate (ksi2(1, num_atoms1(j), mneigh2))
+         allocate (cosp1(1, num_atoms1(i), pmax1, order, mneigh1))
+         allocate (sinp1(1, num_atoms1(i), pmax1, order, mneigh1))
+         allocate (cosp2(1, num_atoms1(j), pmax1, order, mneigh2))
+         allocate (sinp2(1, num_atoms1(j), pmax1, order, mneigh2))
+         allocate (self_scalar1(1, num_atoms1(i)))
+         allocate (self_scalar2(1, num_atoms1(j)))
+       case ("test")
+         ! test x test kernel
+         allocate(v1(1,size(X_te,2),5,size(X_te,4)))
+         allocate(v2(1,size(X_te,2),5,size(X_te,4)))
+         v1(1,:,:,:) = X_te(i, :, :, :)
+         v2(1,:,:,:) = X_te(j, :, :, :)
+         n1 = [num_atoms2(i)]
+         n2 = [num_atoms2(j)]
+         nneigh1_i = reshape(nneigh2(i, :), [1, size(nneigh2, 2)])
+         nneigh2_j = reshape(nneigh2(j, :), [1, size(nneigh2, 2)])
+         mneigh1 = maxval(nneigh1_i)
+         mneigh2 = maxval(nneigh2_j)
+         pm1 = pmax2
+         pm2 = pmax2
+         allocate (ksi1(1, num_atoms2(i), mneigh1))
+         allocate (ksi2(1, num_atoms2(j), mneigh2))
+         allocate (cosp1(1, num_atoms2(i), pmax2, order, mneigh1))
+         allocate (sinp1(1, num_atoms2(i), pmax2, order, mneigh1))
+         allocate (cosp2(1, num_atoms2(j), pmax2, order, mneigh2))
+         allocate (sinp2(1, num_atoms2(j), pmax2, order, mneigh2))
+         allocate (self_scalar1(1, num_atoms2(i)))
+         allocate (self_scalar2(1, num_atoms2(j)))
+       case ("test_train")
+         ! test x train kernel
+         allocate(v1(1,size(X_te,2),5,size(X_te,4)))
+         allocate(v2(1,size(X_tr,2),5,size(X_tr,4)))
+         v1(1,:,:,:) = X_te(i, :, :, :)
+         v2(1,:,:,:) = X_tr(j, :, :, :)
+         ! admittedly confusing, but now 1 = 2
+         n1 = [num_atoms2(i)]
+         n2 = [num_atoms1(j)]
+         nneigh1_i = reshape(nneigh2(i, :), [1, size(nneigh2, 2)])
+         nneigh2_j = reshape(nneigh1(j, :), [1, size(nneigh1, 2)])
+         mneigh1 = maxval(nneigh1_i)
+         mneigh2 = maxval(nneigh2_j)
+         pm1 = pmax2
+         pm2 = pmax1
+         allocate (ksi1(1, num_atoms2(i), mneigh1))
+         allocate (ksi2(1, num_atoms1(j), mneigh2))
+         allocate (cosp1(1, num_atoms2(i), pmax2, order, mneigh1))
+         allocate (sinp1(1, num_atoms2(i), pmax2, order, mneigh1))
+         allocate (cosp2(1, num_atoms1(j), pmax1, order, mneigh2))
+         allocate (sinp2(1, num_atoms1(j), pmax1, order, mneigh2))
+         allocate (self_scalar1(1, num_atoms2(i)))
+         allocate (self_scalar2(1, num_atoms1(j)))
+       case default
+         print *, "Unknown kernel mode: ", mode
+         stop
+      end select
+
+      ! compute ksis
+      call get_ksi(v1, n1, nneigh1_i, two_body_power, cut_start, cut_distance, verbose, ksi1)
+      call get_ksi(v2, n2, nneigh2_j, two_body_power, cut_start, cut_distance, verbose, ksi2)
+
+      n = size(parameters, dim=1)
+      allocate (ktmp(n))
+      allocate(kernels(n))
+      kernels = 0.0d0
+
+      ! Initialize and pre-calculate three-body Fourier terms
+      call init_cosp_sinp(v1, n1, nneigh1_i, three_body_power, order, cut_start, cut_distance, pm1, mneigh1, &
+      & cosp1, sinp1, verbose)
+
+      ! Initialize and pre-calculate three-body Fourier terms
+      call init_cosp_sinp(v2, n2, nneigh2_j, three_body_power, order, cut_start, cut_distance, pm2, mneigh2, &
+      & cosp2, sinp2, verbose)
+
+      ! Pre-calculate self-scalar terms
+      call get_selfscalar(v1, 1, n1, nneigh1_i, ksi1, sinp1, cosp1, t_width, d_width, &
+      & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose,&
+      &self_scalar1)
+
+      ! Pre-calculate self-scalar terms
+      call get_selfscalar(v2, 1, n2, nneigh2_j, ksi2, sinp2, cosp2, t_width, d_width, &
+      & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose,&
+      &self_scalar2)
+
+      do ii = 1, n1(1)
+         do jj = 1, n2(1)
+
+            s12 = scalar(v1(1, ii, :, :), v2(1, jj, :, :), &
+            & nneigh1_i(1, ii), nneigh2_j(1, jj), ksi1(1, ii, :), ksi2(1, jj, :), &
+            & sinp1(1, ii, :, :, :), sinp2(1, jj, :, :, :), &
+            & cosp1(1, ii, :, :, :), cosp2(1, jj, :, :, :), &
+            & t_width, d_width, cut_distance, order, &
+            & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+            !kernels(:, a, b) = kernels(:, a, b) &
+            !    & + kernel(self_scalar1(a, i), self_scalar2(b, j), s12, &
+            !    & kernel_idx, parameters)
+
+            ktmp = 0.0d0
+            call kernel(self_scalar1(1, ii), self_scalar2(1, jj), s12, &
+            & kernel_idx, parameters, ktmp)
+            kernels = kernels + ktmp
+
+         end do
+      end do
+
+      kernel_element = sum(kernels)
+
+      deallocate (v1)
+      deallocate (v2)
+      deallocate (kernels)
+      deallocate (ktmp)
+      deallocate (self_scalar1)
+      deallocate (self_scalar2)
+      deallocate (ksi1)
+      deallocate (ksi2)
+      deallocate (cosp1)
+      deallocate (cosp2)
+      deallocate (sinp1)
+      deallocate (sinp2)
+
+   end function kernel_element
+
+   function train_kernel_element(i, j) result(k)
+      integer, intent(in) :: i, j
+      double precision :: k
+      k = kernel_element(i, j, 'train')
+   end function train_kernel_element
+
+   function test_kernel_element(i, j) result(k)
+      integer, intent(in) :: i, j
+      double precision :: k
+      k = kernel_element(i, j, 'test')
+   end function test_kernel_element
+
+   function test_train_kernel_element(i, j) result(k)
+      integer, intent(in) :: i, j
+      double precision :: k
+      k = kernel_element(i, j, 'test_train')
+   end function test_train_kernel_element
+
+   function train_distance(i, j) result(d)
+      integer, intent(in) :: i, j
+      double precision :: d, d_squared
+
+      d_squared = train_kernel_element(i, i) + train_kernel_element(j, j) - 2 * train_kernel_element(i, j)
+      d_squared = max(d_squared, 0.0d0)
+      d = sqrt(d_squared)
+
+   end function train_distance
+
+   function test_distance(i, j) result(d)
+      integer, intent(in) :: i, j
+      double precision :: d, d_squared
+
+      d_squared = test_kernel_element(i, i) + train_kernel_element(j, j) - 2 * test_train_kernel_element(i, j)
+      d_squared = max(d_squared, 0.0d0)
+      d = sqrt(d_squared)
+
+   end function test_distance
+
+end module kernel_distance

--- a/JKML/src/fortran/ffchl_kernel_types.f90
+++ b/JKML/src/fortran/ffchl_kernel_types.f90
@@ -1,0 +1,19 @@
+module ffchl_kernel_types
+   implicit none
+
+   public
+
+   ! define kernel enums
+   integer, parameter :: GAUSSIAN = 1
+   integer, parameter :: LINEAR = 2
+   integer, parameter :: POLYNOMIAL = 3
+   integer, parameter :: SIGMOID = 4
+   integer, parameter :: MULTIQUADRATIC = 5
+   integer, parameter :: INV_MULTIQUADRATIC = 6
+   integer, parameter :: BESSEL = 7
+   integer, parameter :: L2 = 8
+   integer, parameter :: MATERN = 9
+   integer, parameter :: CAUCHY = 10
+   integer, parameter :: POLYNOMIAL2 = 11
+
+end module ffchl_kernel_types

--- a/JKML/src/fortran/ffchl_kernels.f90
+++ b/JKML/src/fortran/ffchl_kernels.f90
@@ -1,0 +1,311 @@
+module ffchl_kernels
+
+   implicit none
+
+   public :: kernel
+
+contains
+
+   subroutine gaussian_kernel(s11, s22, s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+      double precision :: l2
+
+      l2 = s11 + s22 - 2.0d0*s12
+
+      do i = 1, size(k)
+         k(i) = exp(l2*parameters(i, 1))
+      end do
+
+   end subroutine gaussian_kernel
+
+   subroutine linear_kernel(s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+
+      do i = 1, size(k)
+         k(i) = s12 + parameters(i, 1)
+      end do
+
+   end subroutine linear_kernel
+
+   subroutine polynomial_kernel(s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+
+      do i = 1, size(k)
+         k(i) = (parameters(i, 1)*s12 + parameters(i, 2))**parameters(i, 3)
+      end do
+
+   end subroutine polynomial_kernel
+
+   subroutine sigmoid_kernel(s12, parameters, k)
+
+      implicit none
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+
+      do i = 1, size(k)
+         k(i) = tanh(parameters(i, 1)*s12 + parameters(i, 2))
+      end do
+
+   end subroutine sigmoid_kernel
+
+   subroutine multiquadratic_kernel(s11, s22, s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+      double precision :: l2
+
+      l2 = s11 + s22 - 2.0d0*s12
+
+      do i = 1, size(k)
+         k(i) = sqrt(l2 + parameters(i, 1)**2)
+      end do
+
+   end subroutine multiquadratic_kernel
+
+   subroutine inverse_multiquadratic_kernel(s11, s22, s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+      double precision :: l2
+
+      l2 = s11 + s22 - 2.0d0*s12
+
+      do i = 1, size(k)
+         k(i) = 1.0d0/sqrt(l2 + parameters(i, 1)**2)
+      end do
+
+   end subroutine inverse_multiquadratic_kernel
+
+   subroutine bessel_kernel(s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+
+      do i = 1, size(k)
+         k(i) = BESSEL_JN(int(parameters(i, 2)), parameters(i, 1)*s12) &
+             & /(s12**(-parameters(i, 3)*(parameters(i, 2) + 1)))
+      end do
+
+   end subroutine bessel_kernel
+
+   subroutine l2_kernel(s11, s22, s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+      double precision :: l2
+
+      l2 = s11 + s22 - 2.0d0*s12
+
+      do i = 1, size(k)
+         k(i) = l2*parameters(i, 1) + parameters(i, 2)
+      end do
+
+   end subroutine l2_kernel
+
+   subroutine matern_kernel(s11, s22, s12, parameters, kernel)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: kernel
+
+      double precision :: l2
+
+      double precision :: rho
+
+      integer :: i, k, n
+      double precision:: v, fact
+
+      l2 = sqrt(s11 + s22 - 2.0d0*s12)
+
+      kernel(:) = 0.0d0
+
+      do i = 1, size(kernel)
+         n = int(parameters(i, 2))
+         v = n + 0.5d0
+
+         rho = 2.0d0*sqrt(2.0d0*v)*l2/parameters(i, 1)
+
+         do k = 0, n
+
+            fact = parameters(i, 3 + k)
+
+            kernel(i) = kernel(i) + exp(-0.5d0*rho)*fact*rho**(n - k)
+
+         end do
+      end do
+
+   end subroutine matern_kernel
+
+   subroutine cauchy_kernel(s11, s22, s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+      double precision :: l2
+
+      l2 = s11 + s22 - 2.0d0*s12
+
+      do i = 1, size(k)
+         k(i) = 1.0d0/(1.0d0 + l2/parameters(i, 1)**2)
+      end do
+
+   end subroutine cauchy_kernel
+
+   subroutine polynomial2_kernel(s12, parameters, k)
+
+      implicit none
+
+      double precision, intent(in) :: s12
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      double precision, intent(out), dimension(:) :: k
+
+      integer :: i
+
+      do i = 1, size(k)
+         k(i) = parameters(i, 1) &
+            & + parameters(i, 2)*s12 &
+            & + parameters(i, 3)*s12**2 &
+            & + parameters(i, 4)*s12**3 &
+            & + parameters(i, 5)*s12**4 &
+            & + parameters(i, 6)*s12**5 &
+            & + parameters(i, 7)*s12**6 &
+            & + parameters(i, 8)*s12**7 &
+            & + parameters(i, 9)*s12**8 &
+            & + parameters(i, 10)*s12**9
+      end do
+
+   end subroutine polynomial2_kernel
+
+   !function kernel(s11, s22, s12, kernel_idx, parameters) result(k)
+   subroutine kernel(s11, s22, s12, kernel_idx, parameters, k)
+
+      use ffchl_kernel_types
+
+      implicit none
+
+      double precision, intent(in) :: s11
+      double precision, intent(in) :: s22
+      double precision, intent(in) :: s12
+      integer, intent(in) :: kernel_idx
+      double precision, intent(in), dimension(:, :) :: parameters
+
+      integer :: n
+      !double precision, allocatable, dimension(:) :: k
+      double precision, dimension(:) :: k
+
+      n = size(parameters, dim=1)
+      !allocate (k(n))
+
+      if (kernel_idx == GAUSSIAN) then
+         call gaussian_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == LINEAR) then
+         call linear_kernel(s12, parameters, k)
+
+      else if (kernel_idx == POLYNOMIAL) then
+         call polynomial_kernel(s12, parameters, k)
+
+      else if (kernel_idx == SIGMOID) then
+         call sigmoid_kernel(s12, parameters, k)
+
+      else if (kernel_idx == MULTIQUADRATIC) then
+         call multiquadratic_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == INV_MULTIQUADRATIC) then
+         call inverse_multiquadratic_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == BESSEL) then
+         call bessel_kernel(s12, parameters, k)
+
+      else if (kernel_idx == L2) then
+         call l2_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == MATERN) then
+         call matern_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == CAUCHY) then
+         call cauchy_kernel(s11, s22, s12, parameters, k)
+
+      else if (kernel_idx == POLYNOMIAL2) then
+         call polynomial2_kernel(s12, parameters, k)
+
+      else
+         write (*, *) "QML ERROR: Unknown kernel function requested:", kernel_idx
+         stop
+      end if
+
+   end subroutine kernel
+
+end module ffchl_kernels

--- a/JKML/src/fortran/ffchl_module.f90
+++ b/JKML/src/fortran/ffchl_module.f90
@@ -1,0 +1,1202 @@
+module ffchl_module
+
+   implicit none
+
+contains
+
+   function get_pmax(x, na) result(pmax)
+
+      implicit none
+
+      ! FCHL descriptors for the set, format (nm1,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Internal counter
+      integer :: a
+
+      ! Max nuclear charge
+      integer :: pmax
+
+      pmax = 0
+
+      do a = 1, size(na, dim=1)
+         pmax = max(pmax, int(maxval(x(a, 1, 2, :na(a)))))
+      end do
+
+   end function get_pmax
+
+   function get_pmax_atomic(x, nneigh) result(pmax)
+
+      implicit none
+
+      ! FCHL descriptors for the set, format (nm1,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: nneigh
+
+      ! Internal counter
+      integer :: a
+
+      ! Max nuclear charge
+      integer :: pmax
+
+      pmax = 0
+
+      do a = 1, size(nneigh, dim=1)
+         pmax = max(pmax, int(maxval(x(a, 2, :nneigh(a)))))
+      end do
+
+   end function get_pmax_atomic
+
+   function get_pmax_displaced(x, na) result(pmax)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (nm1,3,2,maxatoms,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Internal counter
+      integer :: a, b, i, xyz, pm
+
+      ! Max nuclear charge
+      integer :: pmax
+
+      pmax = 0
+
+      do a = 1, size(na, dim=1)
+         b = na(a)
+         do xyz = 1, 3
+            do pm = 1, size(x, dim=3)
+               do i = 1, b
+                  pmax = max(pmax, int(maxval(x(a, xyz, pm, i, 1, 2, :na(a)))))
+               end do
+            end do
+         end do
+      end do
+
+   end function get_pmax_displaced
+
+   pure function cut_function(r, cut_start, cut_distance) result(f)
+
+      implicit none
+
+      ! Distance
+      double precision, intent(in) :: r
+
+      ! Lower limit of damping
+      double precision, intent(in) :: cut_start
+
+      ! Upper limit of damping
+      double precision, intent(in) :: cut_distance
+
+      ! Intermediate variables
+      double precision :: x
+      double precision :: rl
+      double precision :: ru
+
+      ! Damping function at distance r
+      double precision :: f
+
+      ru = cut_distance
+      rl = cut_start*cut_distance
+
+      if (r > ru) then
+
+         f = 0.0d0
+
+      else if (r < rl) then
+
+         f = 1.0d0
+
+      else
+
+         x = (ru - r)/(ru - rl)
+         f = (10.0d0*x**3) - (15.0d0*x**4) + (6.0d0*x**5)
+
+      end if
+
+   end function cut_function
+
+   pure function get_angular_norm2(t_width) result(ang_norm2)
+
+      implicit none
+
+      ! Theta-width
+      double precision, intent(in) :: t_width
+
+      ! The resulting angular norm (squared)
+      double precision ang_norm2
+
+      ! Integration limit - bigger than 100 should suffice.
+      integer, parameter :: limit = 10000
+
+      ! Pi at double precision.
+      double precision, parameter :: pi = 4.0d0*atan(1.0d0)
+
+      integer :: n
+
+      ang_norm2 = 0.0d0
+
+      do n = -limit, limit
+         ang_norm2 = ang_norm2 + exp(-((t_width*n)**2)) &
+         & *(2.0d0 - 2.0d0*cos(n*pi))
+      end do
+
+      ang_norm2 = sqrt(ang_norm2*pi)*2.0d0
+
+   end function
+
+   function get_twobody_weights(x, neighbors, power, cut_start, cut_distance, dim1) result(ksi)
+
+      implicit none
+
+      double precision, dimension(:, :), intent(in) :: x
+      integer, intent(in) :: neighbors
+      double precision, intent(in) :: power
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+      integer, intent(in) :: dim1
+
+      double precision, dimension(dim1) :: ksi
+      integer :: i
+
+      ksi = 0.0d0
+
+      do i = 2, neighbors
+
+         ksi(i) = cut_function(x(1, i), cut_start, cut_distance)/x(1, i)**power
+
+      end do
+
+   end function get_twobody_weights
+
+! Calculate the Fourier terms for the FCHL three-body expansion
+   function get_threebody_fourier(x, neighbors, order, power, cut_start, cut_distance, &
+   & dim1, dim2, dim3) result(fourier)
+
+      implicit none
+
+      ! Input representation, dimension=(5,n).
+      double precision, dimension(:, :), intent(in) :: x
+
+      ! Number of neighboring atoms to iterate over.
+      integer, intent(in) :: neighbors
+
+      ! Fourier-expansion order.
+      integer, intent(in) :: order
+
+      ! Power law
+      double precision, intent(in) :: power
+
+      ! Lower limit of damping function
+      double precision, intent(in) :: cut_start
+
+      ! Upper limit of damping function
+      double precision, intent(in) :: cut_distance
+
+      ! Dimensions or the output array.
+      integer, intent(in) :: dim1, dim2, dim3
+
+      ! dim(1,:,:,:) are cos terms, dim(2,:,:,:) are sine terms.
+      double precision, dimension(2, dim1, dim2, dim3) :: fourier
+
+      ! Pi at double precision.
+      double precision, parameter :: pi = 4.0d0*atan(1.0d0)
+
+      ! Internal counters.
+      integer :: j, k, m
+
+      ! Indexes for the periodic-table distance matrix.
+      integer :: pj, pk
+
+      ! Angle between atoms for the three-body term.
+      double precision :: theta
+
+      ! Three-body weight
+      double precision :: ksi3
+
+      ! Temporary variables for cos and sine Fourier terms.
+      double precision :: cos_m, sin_m
+
+      fourier = 0.0d0
+
+      do j = 2, neighbors
+         do k = j + 1, neighbors
+
+            ksi3 = calc_ksi3(X(:, :), j, k, power, cut_start, cut_distance)
+            theta = calc_angle(x(3:5, j), x(3:5, 1), x(3:5, k))
+
+            pj = int(x(2, k))
+            pk = int(x(2, j))
+
+            do m = 1, order
+
+               cos_m = (cos(m*theta) - cos((theta + pi)*m))*ksi3
+               sin_m = (sin(m*theta) - sin((theta + pi)*m))*ksi3
+
+               fourier(1, pj, m, j) = fourier(1, pj, m, j) + cos_m
+               fourier(2, pj, m, j) = fourier(2, pj, m, j) + sin_m
+
+               fourier(1, pk, m, k) = fourier(1, pk, m, k) + cos_m
+               fourier(2, pk, m, k) = fourier(2, pk, m, k) + sin_m
+
+            end do
+
+         end do
+      end do
+
+      return
+
+   end function get_threebody_fourier
+
+   pure function calc_angle(a, b, c) result(angle)
+
+      implicit none
+
+      double precision, intent(in), dimension(3) :: a
+      double precision, intent(in), dimension(3) :: b
+      double precision, intent(in), dimension(3) :: c
+
+      double precision, dimension(3) :: v1
+      double precision, dimension(3) :: v2
+
+      double precision :: cos_angle
+      double precision :: angle
+
+      v1 = a - b
+      v2 = c - b
+
+      v1 = v1/norm2(v1)
+      v2 = v2/norm2(v2)
+
+      cos_angle = dot_product(v1, v2)
+
+      ! Clipping
+      if (cos_angle > 1.0d0) cos_angle = 1.0d0
+      if (cos_angle < -1.0d0) cos_angle = -1.0d0
+
+      angle = acos(cos_angle)
+
+   end function calc_angle
+
+   pure function calc_cos_angle(a, b, c) result(cos_angle)
+
+      implicit none
+
+      double precision, intent(in), dimension(3) :: a
+      double precision, intent(in), dimension(3) :: b
+      double precision, intent(in), dimension(3) :: c
+
+      double precision, dimension(3) :: v1
+      double precision, dimension(3) :: v2
+
+      double precision :: cos_angle
+
+      v1 = a - b
+      v2 = c - b
+
+      v1 = v1/norm2(v1)
+      v2 = v2/norm2(v2)
+
+      cos_angle = dot_product(v1, v2)
+
+   end function calc_cos_angle
+
+   function calc_ksi3(X, j, k, power, cut_start, cut_distance) result(ksi3)
+
+      implicit none
+
+      double precision, dimension(:, :), intent(in) :: X
+
+      integer, intent(in) :: j
+      integer, intent(in) :: k
+      double precision, intent(in) :: power
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      double precision :: cos_i, cos_j, cos_k
+      double precision :: di, dj, dk
+
+      double precision :: ksi3
+      double precision :: cut
+
+      cos_i = calc_cos_angle(x(3:5, k), x(3:5, 1), x(3:5, j))
+      cos_j = calc_cos_angle(x(3:5, j), x(3:5, k), x(3:5, 1))
+      cos_k = calc_cos_angle(x(3:5, 1), x(3:5, j), x(3:5, k))
+
+      dk = x(1, j)
+      dj = x(1, k)
+      di = norm2(x(3:5, j) - x(3:5, k))
+
+      cut = cut_function(dk, cut_start, cut_distance)* &
+      & cut_function(dj, cut_start, cut_distance)* &
+      & cut_function(di, cut_start, cut_distance)
+
+      ksi3 = cut*(1.0d0 + 3.0d0*cos_i*cos_j*cos_k)/(di*dj*dk)**power
+
+   end function calc_ksi3
+
+   pure function scalar(X1, X2, N1, N2, ksi1, ksi2, sin1, sin2, cos1, cos2, &
+   & t_width, d_width, cut_distance, order, pd, ang_norm2, &
+   & distance_scale, angular_scale, alchemy) result(aadist)
+
+      implicit none
+
+      double precision, dimension(:, :), intent(in) :: X1
+      double precision, dimension(:, :), intent(in) :: X2
+
+      integer, intent(in) :: N1
+      integer, intent(in) :: N2
+
+      double precision, dimension(:), intent(in) :: ksi1
+      double precision, dimension(:), intent(in) :: ksi2
+
+      double precision, dimension(:, :, :), intent(in) :: sin1
+      double precision, dimension(:, :, :), intent(in) :: sin2
+      double precision, dimension(:, :, :), intent(in) :: cos1
+      double precision, dimension(:, :, :), intent(in) :: cos2
+
+      double precision, intent(in) :: t_width
+      double precision, intent(in) :: d_width
+      double precision, intent(in) :: cut_distance
+      integer, intent(in) :: order
+      double precision, dimension(:, :), intent(in) :: pd
+      double precision, intent(in) :: angular_scale
+      double precision, intent(in) :: distance_scale
+
+      double precision :: true_angular_scale
+      double precision :: true_distance_scale
+
+      double precision, intent(in):: ang_norm2
+
+      double precision :: aadist
+
+      logical, intent(in) :: alchemy
+
+      ! We changed the convention for the scaling factors when the paper was under review
+      ! so this is a quick fix
+      true_angular_scale = angular_scale/sqrt(8.0d0)
+      true_distance_scale = distance_scale/16.0d0
+
+      if (alchemy) then
+         aadist = scalar_alchemy(X1, X2, N1, N2, ksi1, ksi2, sin1, sin2, cos1, cos2, &
+         & t_width, d_width, order, pd, ang_norm2, &
+         & true_distance_scale, true_angular_scale)
+      else
+         aadist = scalar_noalchemy(X1, X2, N1, N2, ksi1, ksi2, sin1, sin2, cos1, cos2, &
+         & t_width, d_width, ang_norm2, &
+         & true_distance_scale, true_angular_scale)
+      end if
+
+   end function scalar
+
+   pure function scalar_noalchemy(X1, X2, N1, N2, ksi1, ksi2, sin1, sin2, cos1, cos2, &
+   & t_width, d_width, ang_norm2, &
+   & distance_scale, angular_scale) result(aadist)
+
+      implicit none
+
+      double precision, dimension(:, :), intent(in) :: X1
+      double precision, dimension(:, :), intent(in) :: X2
+
+      integer, intent(in) :: N1
+      integer, intent(in) :: N2
+
+      double precision, dimension(:), intent(in) :: ksi1
+      double precision, dimension(:), intent(in) :: ksi2
+
+      double precision, dimension(:, :, :), intent(in) :: sin1
+      double precision, dimension(:, :, :), intent(in) :: sin2
+      double precision, dimension(:, :, :), intent(in) :: cos1
+      double precision, dimension(:, :, :), intent(in) :: cos2
+
+      double precision, intent(in) :: t_width
+      double precision, intent(in) :: d_width
+
+      double precision, intent(in) :: angular_scale
+      double precision, intent(in) :: distance_scale
+
+      double precision :: aadist
+
+      double precision :: d
+
+      integer :: i, j, p
+      double precision :: angular
+      double precision :: maxgausdist2
+
+      integer :: pmax1
+      integer :: pmax2
+      integer :: pmax
+
+      double precision :: inv_width
+      double precision :: r2
+
+      double precision :: s
+
+      double precision, parameter :: pi = 4.0d0*atan(1.0d0)
+
+      double precision :: g1
+
+      logical, allocatable, dimension(:) :: mask1
+      logical, allocatable, dimension(:) :: mask2
+
+      double precision, intent(in):: ang_norm2
+
+      ! cached sine and cos terms
+      double precision, allocatable, dimension(:, :) :: cos1c, cos2c, sin1c, sin2c
+
+      if (int(x1(2, 1)) /= int(x2(2, 1))) then
+         aadist = 0.0d0
+         return
+      end if
+
+      pmax1 = int(maxval(x1(2, :n1)))
+      pmax2 = int(maxval(x2(2, :n2)))
+
+      pmax = min(pmax1, pmax2)
+
+      allocate (mask1(pmax1))
+      allocate (mask2(pmax2))
+      mask1 = .true.
+      mask2 = .true.
+
+      do i = 1, n1
+         mask1(int(x1(2, i))) = .false.
+      end do
+
+      do i = 1, n2
+         mask2(int(x2(2, i))) = .false.
+      end do
+
+      allocate (cos1c(pmax, n1))
+      allocate (cos2c(pmax, n2))
+      allocate (sin1c(pmax, n1))
+      allocate (sin2c(pmax, n2))
+
+      cos1c = 0.0d0
+      cos2c = 0.0d0
+      sin1c = 0.0d0
+      sin2c = 0.0d0
+
+      p = 0
+
+      do i = 1, pmax
+         if (mask1(i)) cycle
+         if (mask2(i)) cycle
+
+         p = p + 1
+
+         cos1c(p, :n1) = cos1(i, 1, :n1)
+         cos2c(p, :n2) = cos2(i, 1, :n2)
+         sin1c(p, :n1) = sin1(i, 1, :n1)
+         sin2c(p, :n2) = sin2(i, 1, :n2)
+
+      end do
+
+      pmax = p
+
+      ! Pre-computed constants
+      g1 = sqrt(2.0d0*pi)/ang_norm2
+      s = g1*exp(-(t_width)**2/2.0d0)
+      inv_width = -1.0d0/(4.0d0*d_width**2)
+      maxgausdist2 = (8.0d0*d_width)**2
+
+      ! Initialize scalar product
+      aadist = 1.0d0
+
+      do i = 2, n1
+         do j = 2, n2
+
+            if (int(x1(2, i)) /= int(x2(2, j))) cycle
+
+            r2 = (x2(1, j) - x1(1, i))**2
+            if (r2 >= maxgausdist2) cycle
+
+            d = exp(r2*inv_width)
+
+            angular = (sum(cos1c(:pmax, i)*cos2c(:pmax, j)) &
+            & + sum(sin1c(:pmax, i)*sin2c(:pmax, j)))*s
+
+            aadist = aadist + d*(ksi1(i)*ksi2(j)*distance_scale &
+            & + angular*angular_scale)
+
+         end do
+      end do
+
+      deallocate (mask1)
+      deallocate (mask2)
+      deallocate (cos1c)
+      deallocate (cos2c)
+      deallocate (sin1c)
+      deallocate (sin2c)
+
+   end function scalar_noalchemy
+
+   pure function scalar_alchemy(X1, X2, N1, N2, ksi1, ksi2, sin1, sin2, cos1, cos2, &
+   & t_width, d_width, order, pd, ang_norm2, &
+   & distance_scale, angular_scale) result(aadist)
+
+      implicit none
+
+      double precision, dimension(:, :), intent(in) :: X1
+      double precision, dimension(:, :), intent(in) :: X2
+
+      integer, intent(in) :: N1
+      integer, intent(in) :: N2
+
+      double precision, dimension(:), intent(in) :: ksi1
+      double precision, dimension(:), intent(in) :: ksi2
+
+      double precision, dimension(:, :, :), intent(in) :: sin1
+      double precision, dimension(:, :, :), intent(in) :: sin2
+      double precision, dimension(:, :, :), intent(in) :: cos1
+      double precision, dimension(:, :, :), intent(in) :: cos2
+
+      double precision, intent(in) :: t_width
+      double precision, intent(in) :: d_width
+      ! double precision, intent(in) :: cut_distance
+      integer, intent(in) :: order
+      double precision, dimension(:, :), intent(in) :: pd
+      double precision, intent(in) :: angular_scale
+      double precision, intent(in) :: distance_scale
+
+      double precision :: aadist
+
+      double precision :: d
+
+      integer :: m_1, m_2
+
+      integer :: i, m, p1, p2
+
+      double precision :: angular
+      double precision :: maxgausdist2
+
+      integer :: pmax1
+      integer :: pmax2
+
+      double precision :: inv_width
+      double precision :: r2
+
+      double precision, dimension(order) :: s
+
+      double precision, parameter :: pi = 4.0d0*atan(1.0d0)
+
+      double precision :: g1
+      double precision :: a0
+
+      logical, allocatable, dimension(:) :: mask1
+      logical, allocatable, dimension(:) :: mask2
+
+      double precision :: temp, sin1_temp, cos1_temp
+      double precision, intent(in):: ang_norm2
+
+      pmax1 = int(maxval(x1(2, :n1)))
+      pmax2 = int(maxval(x2(2, :n2)))
+
+      allocate (mask1(pmax1))
+      allocate (mask2(pmax2))
+      mask1 = .true.
+      mask2 = .true.
+
+      do i = 1, n1
+         mask1(int(x1(2, i))) = .false.
+      end do
+
+      do i = 1, n2
+         mask2(int(x2(2, i))) = .false.
+      end do
+
+      a0 = 0.0d0
+      g1 = sqrt(2.0d0*pi)/ang_norm2
+
+      do m = 1, order
+         s(m) = g1*exp(-(t_width*m)**2/2.0d0)
+      end do
+
+      inv_width = -1.0d0/(4.0d0*d_width**2)
+
+      maxgausdist2 = (8.0d0*d_width)**2
+
+      aadist = 1.0d0
+
+      do m_1 = 2, N1
+
+         ! if (X1(1, m_1) > cut_distance) exit
+
+         do m_2 = 2, N2
+
+            ! if (X2(1, m_2) > cut_distance) exit
+
+            r2 = (X2(1, m_2) - X1(1, m_1))**2
+
+            if (r2 < maxgausdist2) then
+
+               d = exp(r2*inv_width)*pd(int(x1(2, m_1)), int(x2(2, m_2)))
+
+               angular = a0*a0
+
+               do m = 1, order
+
+                  temp = 0.0d0
+
+                  do p1 = 1, pmax1
+                     if (mask1(p1)) cycle
+                     cos1_temp = cos1(p1, m, m_1)
+                     sin1_temp = sin1(p1, m, m_1)
+
+                     do p2 = 1, pmax2
+                        if (mask2(p2)) cycle
+
+                        temp = temp + (cos1_temp*cos2(p2, m, m_2) &
+                        & + sin1_temp*sin2(p2, m, m_2))*pd(p2, p1)
+
+                     end do
+                  end do
+
+                  angular = angular + temp*s(m)
+
+               end do
+
+               aadist = aadist + d*(ksi1(m_1)*ksi2(m_2)*distance_scale &
+               & + angular*angular_scale)
+
+            end if
+         end do
+      end do
+
+      aadist = aadist*pd(int(x1(2, 1)), int(x2(2, 1)))
+
+      deallocate (mask1)
+      deallocate (mask2)
+   end function scalar_alchemy
+
+   subroutine get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose, ksi)! result(ksi)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: two_body_power
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Pre-computed two-body weights
+      !double precision, allocatable, dimension(:, :, :) :: ksi
+      double precision, dimension(:, :, :) :: ksi
+
+      ! Internal counters
+      integer :: maxneigh, maxatoms, nm, a, ni, i
+
+      maxneigh = maxval(nneigh)
+      maxatoms = maxval(na)
+      nm = size(x, dim=1)
+
+      !allocate (ksi(nm, maxatoms, maxneigh))
+
+      ksi = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(ni)
+      do a = 1, nm
+         ni = na(a)
+         do i = 1, ni
+            ksi(a, i, :) = get_twobody_weights(x(a, i, :, :), nneigh(a, i), &
+            & two_body_power, cut_start, cut_distance, maxneigh)
+         end do
+      end do
+      !$OMP END PARALLEL do
+
+      !end function get_ksi
+   end subroutine get_ksi
+
+   !function get_ksi_displaced(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose) result(ksi)
+   subroutine get_ksi_displaced(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose, ksi)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :, :, :, :), intent(in) :: nneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: two_body_power
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Pre-computed two-body weights
+      !double precision, allocatable, dimension(:, :, :, :, :, :) :: ksi
+      double precision, dimension(:, :, :, :, :, :), intent(out) :: ksi
+
+      ! Internal counters
+      integer :: maxneigh, maxatoms, nm, a, ni, i, j, pm, xyz, ndisp
+
+      maxneigh = maxval(nneigh)
+      maxatoms = maxval(na)
+      nm = size(x, dim=1)
+      ndisp = size(x, dim=3)
+
+      !allocate (ksi(nm, 3, ndisp, maxatoms, maxatoms, maxneigh))
+
+      ksi = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(ni)
+      do a = 1, nm
+         ni = na(a)
+         do xyz = 1, 3
+            do pm = 1, ndisp
+               do i = 1, ni
+                  do j = 1, ni
+                     ksi(a, xyz, pm, i, j, :) = get_twobody_weights( &
+                     & x(a, xyz, pm, i, j, :, :), nneigh(a, xyz, pm, i, j), &
+                     & two_body_power, cut_start, cut_distance, maxneigh)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$OMP END PARALLEL do
+
+      !end function get_ksi_displaced
+   end subroutine get_ksi_displaced
+
+   !function get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose) result(ksi)
+   subroutine get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose, ksi)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :), intent(in) :: x
+
+      ! List of numbers of atoms
+      integer, intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:), intent(in) :: nneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: two_body_power
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Pre-computed two-body weights
+      ! double precision, allocatable, dimension(:, :) :: ksi
+      double precision, dimension(:, :), intent(out) :: ksi
+
+      ! Internal counters
+      integer :: maxneigh, nm, i
+
+      maxneigh = maxval(nneigh)
+      nm = size(x, dim=1)
+
+      ! allocate (ksi(na, maxneigh))
+
+      ksi = 0.0d0
+
+      !$OMP PARALLEL DO
+      do i = 1, na
+         ksi(i, :) = get_twobody_weights(x(i, :, :), nneigh(i), &
+         & two_body_power, cut_start, cut_distance, maxneigh)
+      end do
+      !$OMP END PARALLEL do
+
+      !end function get_ksi_atomic
+   end subroutine get_ksi_atomic
+
+   subroutine init_cosp_sinp(x, na, nneigh, three_body_power, order, cut_start, cut_distance, pmax, maxneigh, cosp, sinp, verbose)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh
+      ! maximum number of neighbors
+      integer, intent(in) :: maxneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: three_body_power
+
+      ! pmax
+      integer, intent(in) :: pmax
+
+      integer, intent(in) :: order
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Cosine and sine terms for each atomtype
+      double precision, dimension(:, :, :, :, :), intent(out) :: cosp
+      double precision, dimension(:, :, :, :, :), intent(out) :: sinp
+
+      ! Internal counters
+      integer :: maxatoms, nm, a, ni, i
+
+      double precision, allocatable, dimension(:, :, :, :) :: fourier
+
+      maxatoms = maxval(na)
+      nm = size(x, dim=1)
+
+      cosp = 0.0d0
+      sinp = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(ni, fourier) schedule(dynamic)
+      do a = 1, nm
+         ni = na(a)
+         do i = 1, ni
+
+            fourier = get_threebody_fourier(x(a, i, :, :), &
+            & nneigh(a, i), order, three_body_power, cut_start, cut_distance, pmax, order, maxneigh)
+
+            cosp(a, i, :, :, :) = fourier(1, :, :, :)
+            sinp(a, i, :, :, :) = fourier(2, :, :, :)
+
+         end do
+      end do
+      !$OMP END PARALLEL DO
+
+   end subroutine init_cosp_sinp
+
+   subroutine init_cosp_sinp_displaced(x, na, nneigh, three_body_power, order, cut_start, cut_distance, cosp, sinp, verbose)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: x
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :, :, :, :), intent(in) :: nneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: three_body_power
+
+      integer, intent(in) :: order
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Cosine and sine terms for each atomtype
+      double precision, dimension(:, :, :, :, :, :, :) :: sinp
+      double precision, dimension(:, :, :, :, :, :, :) :: cosp
+
+      ! Internal counters
+      integer :: maxneigh, maxatoms, pmax, nm, a, ni, i, j, xyz, pm, xyz_pm
+
+      double precision, allocatable, dimension(:, :, :, :) :: fourier
+
+      integer :: ndisp
+
+      maxneigh = maxval(nneigh)
+      maxatoms = maxval(na)
+      nm = size(x, dim=1)
+
+      ndisp = size(x, dim=3)
+
+      pmax = get_pmax_displaced(x, na)
+
+      cosp = 0.0d0
+      sinp = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(ni, fourier, xyz_pm) schedule(dynamic)
+      do a = 1, nm
+         ni = na(a)
+         do xyz = 1, 3
+            do pm = 1, ndisp
+               do i = 1, ni
+                  do j = 1, ni
+
+                     xyz_pm = ndisp*(xyz - 1) + pm
+
+                     fourier = get_threebody_fourier(x(a, xyz, pm, i, j, :, :), &
+                     & nneigh(a, xyz, pm, i, j), &
+                     & order, three_body_power, cut_start, cut_distance, &
+                     & pmax, order, maxneigh)
+
+                     cosp(a, xyz_pm, i, j, :, :, :) = fourier(1, :, :, :)
+                     sinp(a, xyz_pm, i, j, :, :, :) = fourier(2, :, :, :)
+
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$OMP END PARALLEL do
+
+   end subroutine init_cosp_sinp_displaced
+
+   subroutine init_cosp_sinp_atomic(x, na, nneigh, three_body_power, order, cut_start, cut_distance, cosp, sinp, verbose)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :), intent(in) :: x
+
+      ! List of numbers of atom
+      integer, intent(in) :: na
+
+      ! Number of neighbors for each atom
+      integer, dimension(:), intent(in) :: nneigh
+
+      ! Decaying powerlaws for two-body term
+      double precision, intent(in) :: three_body_power
+
+      ! Fourier truncation order
+      integer, intent(in) :: order
+
+      ! Fraction of cut_distance at which cut-off starts
+      double precision, intent(in) :: cut_start
+      double precision, intent(in) :: cut_distance
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      ! Cosine and sine terms for each atomtype
+      double precision, dimension(:, :, :, :), intent(out) :: cosp
+      double precision, dimension(:, :, :, :), intent(out) :: sinp
+
+      ! Internal counters
+      integer :: maxneigh, pmax, nm, i
+
+      ! Internal temporary variable
+      double precision, allocatable, dimension(:, :, :, :) :: fourier
+
+      maxneigh = maxval(nneigh)
+      nm = size(x, dim=1)
+
+      pmax = get_pmax_atomic(x, nneigh)
+
+      cosp = 0.0d0
+      sinp = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(fourier)
+      do i = 1, na
+
+         fourier = get_threebody_fourier(x(i, :, :), &
+         & nneigh(i), order, three_body_power, cut_start, cut_distance, pmax, order, maxneigh)
+
+         cosp(i, :, :, :) = fourier(1, :, :, :)
+         sinp(i, :, :, :) = fourier(2, :, :, :)
+
+      end do
+      !$OMP END PARALLEL DO
+
+   end subroutine init_cosp_sinp_atomic
+
+   !function get_selfscalar(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
+   !        & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose) result(self_scalar)
+   subroutine get_selfscalar(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose, self_scalar)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :), intent(in) :: x
+
+      ! Number of molecules molecule
+      integer, intent(in) :: nm
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :), intent(in) :: nneigh
+
+      ! Pre-computed two-body weights
+      double precision, dimension(:, :, :), intent(in) :: ksi
+
+      ! Cosine and sine terms for each atomtype
+      double precision, dimension(:, :, :, :, :), intent(in) :: sinp
+      double precision, dimension(:, :, :, :, :), intent(in) :: cosp
+
+      ! Angular Gaussian width
+      double precision, intent(in) :: t_width
+
+      ! Distance Gaussian width
+      double precision, intent(in) :: d_width
+
+      double precision, intent(in) :: cut_distance
+
+      ! Truncation order for Fourier terms
+      integer, intent(in) :: order
+
+      ! Periodic table distance matrix
+      double precision, dimension(:, :), intent(in) :: pd
+
+      ! Angular normalization constant
+      double precision, intent(in) :: ang_norm2
+
+      ! Scaling for angular and distance terms
+      double precision, intent(in) :: distance_scale
+      double precision, intent(in) :: angular_scale
+
+      ! Switch alchemy on or off
+      logical, intent(in) :: alchemy
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      !double precision, allocatable, dimension(:, :) :: self_scalar
+      double precision, dimension(:, :) :: self_scalar
+
+      ! Internal counters
+      integer :: a, ni, i
+
+      !allocate (self_scalar(nm, maxval(na)))
+
+      !$OMP PARALLEL DO PRIVATE(ni)
+      do a = 1, nm
+         ni = na(a)
+         do i = 1, ni
+            self_scalar(a, i) = scalar(x(a, i, :, :), x(a, i, :, :), &
+            & nneigh(a, i), nneigh(a, i), ksi(a, i, :), ksi(a, i, :), &
+            & sinp(a, i, :, :, :), sinp(a, i, :, :, :), &
+            & cosp(a, i, :, :, :), cosp(a, i, :, :, :), &
+            & t_width, d_width, cut_distance, order, &
+            & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+         end do
+      end do
+      !$OMP END PARALLEL DO
+
+      !end function get_selfscalar
+   end subroutine get_selfscalar
+
+   !function get_selfscalar_displaced(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
+   !        & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose) result(self_scalar)
+   subroutine get_selfscalar_displaced(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose, self_scalar)
+
+      implicit none
+
+      ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: x
+
+      ! Number of molecules molecule
+      integer, intent(in) :: nm
+
+      ! List of numbers of atoms in each molecule
+      integer, dimension(:), intent(in) :: na
+
+      ! Number of neighbors for each atom in each compound
+      integer, dimension(:, :, :, :, :), intent(in) :: nneigh
+
+      ! Pre-computed two-body weights
+      double precision, dimension(:, :, :, :, :, :), intent(in) :: ksi
+
+      ! Cosine and sine terms for each atomtype
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: sinp
+      double precision, dimension(:, :, :, :, :, :, :), intent(in) :: cosp
+
+      ! Angular Gaussian width
+      double precision, intent(in) :: t_width
+
+      ! Distance Gaussian width
+      double precision, intent(in) :: d_width
+
+      double precision, intent(in) :: cut_distance
+
+      ! Truncation order for Fourier terms
+      integer, intent(in) :: order
+
+      ! Periodic table distance matrix
+      double precision, dimension(:, :), intent(in) :: pd
+
+      ! Angular normalization constant
+      double precision, intent(in) :: ang_norm2
+
+      ! Scaling for angular and distance terms
+      double precision, intent(in) :: distance_scale
+      double precision, intent(in) :: angular_scale
+
+      ! Switch alchemy on or off
+      logical, intent(in) :: alchemy
+
+      ! Whether to be verbose with output
+      logical, intent(in) :: verbose
+
+      !double precision, allocatable, dimension(:, :, :, :, :) :: self_scalar
+      double precision, dimension(:, :, :, :, :) :: self_scalar
+
+      ! Internal counters
+      integer :: a, ni, i, j, pm, xyz, xyz_pm, ndisp
+
+      ndisp = size(x, dim=3)
+      ! allocate (self_scalar(nm, 3, ndisp, maxval(na), maxval(na)))
+      self_scalar = 0.0d0
+
+      !$OMP PARALLEL DO PRIVATE(ni, xyz_pm) schedule(dynamic)
+      do a = 1, nm
+         ni = na(a)
+         do xyz = 1, 3
+            do pm = 1, ndisp
+               do i = 1, ni
+                  do j = 1, ni
+
+                     ! z_pm = 2*xyz + pm - 2
+                     xyz_pm = ndisp*(xyz - 1) + pm
+
+                     self_scalar(a, xyz, pm, i, j) = scalar(x(a, xyz, pm, i, j, :, :), x(a, xyz, pm, i, j, :, :), &
+                     & nneigh(a, xyz, pm, i, j), nneigh(a, xyz, pm, i, j), &
+                     & ksi(a, xyz, pm, i, j, :), ksi(a, xyz, pm, i, j, :), &
+                     & sinp(a, xyz_pm, i, j, :, :, :), sinp(a, xyz_pm, i, j, :, :, :), &
+                     & cosp(a, xyz_pm, i, j, :, :, :), cosp(a, xyz_pm, i, j, :, :, :), &
+                     & t_width, d_width, cut_distance, order, &
+                     & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$OMP END PARALLEL do
+
+      !end function get_selfscalar_displaced
+   end subroutine get_selfscalar_displaced
+
+end module ffchl_module

--- a/JKML/src/fortran/ffchl_scalar_kernels.f90
+++ b/JKML/src/fortran/ffchl_scalar_kernels.f90
@@ -1,0 +1,1214 @@
+subroutine fget_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, nm1, nm2, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
+
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+   double precision, dimension(:, :, :, :), intent(in) :: x1
+   double precision, dimension(:, :, :, :), intent(in) :: x2
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! List of numbers of atoms in each molecule
+   integer, dimension(:), intent(in) :: n1
+   integer, dimension(:), intent(in) :: n2
+
+   ! Number of molecules
+   integer, intent(in) :: nm1
+   integer, intent(in) :: nm2
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:, :), intent(in) :: nneigh1
+   integer, dimension(:, :), intent(in) :: nneigh2
+
+   ! Angular Gaussian width
+   double precision, intent(in) :: t_width
+
+   ! Distance Gaussian width
+   double precision, intent(in) :: d_width
+
+   ! Fraction of cut_distance at which cut-off starts
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+
+   ! Truncation order for Fourier terms
+   integer, intent(in) :: order
+
+   ! Periodic table distance matrix
+   double precision, dimension(:, :), intent(in) :: pd
+
+   ! Scaling for angular and distance terms
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+
+   ! Switch alchemy on or off
+   logical, intent(in) :: alchemy
+
+   ! Decaying power laws for two- and three-body terms
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   ! Kernel ID and corresponding parameters
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, nm1, nm2), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j
+   integer :: ni, nj
+   integer :: a, b
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:, :) :: self_scalar1
+   double precision, allocatable, dimension(:, :) :: self_scalar2
+
+   ! Pre-computed two-body weights
+   double precision, allocatable, dimension(:, :, :) :: ksi1
+   double precision, allocatable, dimension(:, :, :) :: ksi2
+
+   ! Pre-computed terms for the Fourier expansion of the three-body term
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp2
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp2
+
+   ! Max index in the periodic table
+   integer :: pmax1
+   integer :: pmax2
+
+   ! Angular normalization constant
+   double precision :: ang_norm2
+
+   ! Max number of neighbors
+   integer :: maxneigh1
+   integer :: maxneigh2
+
+   ! Work kernel space
+   integer :: n
+   double precision, allocatable, dimension(:) :: ktmp
+
+   kernels(:, :, :) = 0.0d0
+
+   ! Get max number of neighbors
+   maxneigh1 = maxval(nneigh1)
+   maxneigh2 = maxval(nneigh2)
+
+   ! Calculate angular normalization constant
+   ang_norm2 = get_angular_norm2(t_width)
+
+   ! pmax = max nuclear charge
+   pmax1 = get_pmax(x1, n1)
+   pmax2 = get_pmax(x2, n2)
+
+   ! Get two-body weight function
+   !ksi1 = get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+   !ksi2 = get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose)
+
+   !  subroutine get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose, ksi)! result(ksi)
+   ! maxneigh = maxval(nneigh)
+   ! maxatoms = maxval(na)
+   ! nm = size(x, dim=1)
+   allocate (ksi1(size(x1, dim=1), maxval(n1), maxval(nneigh1)))
+   allocate (ksi2(size(x2, dim=1), maxval(n2), maxval(nneigh2)))
+   call get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   call get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose, ksi2)
+
+   n = size(parameters, dim=1)
+   allocate (ktmp(n))
+
+   ! Allocate three-body Fourier terms
+   allocate (cosp1(nm1, maxval(n1), pmax1, order, maxneigh1))
+   allocate (sinp1(nm1, maxval(n1), pmax1, order, maxneigh1))
+
+   ! Initialize and pre-calculate three-body Fourier terms
+   call init_cosp_sinp(x1, n1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   ! Allocate three-body Fourier terms
+   allocate (cosp2(nm2, maxval(n2), pmax2, order, maxneigh2))
+   allocate (sinp2(nm2, maxval(n2), pmax2, order, maxneigh2))
+
+   ! Initialize and pre-calculate three-body Fourier terms
+   call init_cosp_sinp(x2, n2, nneigh2, three_body_power, order, cut_start, cut_distance, &
+   & cosp2, sinp2, verbose)
+
+   ! Pre-calculate self-scalar terms
+   !self_scalar1 = get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   !     & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose)
+   allocate (self_scalar1(nm1, maxval(n1)))
+   call get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose,&
+   &self_scalar1)
+
+   ! Pre-calculate self-scalar terms
+   !self_scalar2 = get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
+   !     & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose)
+   allocate (self_scalar2(nm2, maxval(n2)))
+   call get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose,&
+   &self_scalar2)
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,ktmp)
+   do b = 1, nm2
+      nj = n2(b)
+      do a = 1, nm1
+         ni = n1(a)
+
+         do i = 1, ni
+            do j = 1, nj
+
+               s12 = scalar(x1(a, i, :, :), x2(b, j, :, :), &
+               & nneigh1(a, i), nneigh2(b, j), ksi1(a, i, :), ksi2(b, j, :), &
+               & sinp1(a, i, :, :, :), sinp2(b, j, :, :, :), &
+               & cosp1(a, i, :, :, :), cosp2(b, j, :, :, :), &
+               & t_width, d_width, cut_distance, order, &
+               & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+               !kernels(:, a, b) = kernels(:, a, b) &
+               !    & + kernel(self_scalar1(a, i), self_scalar2(b, j), s12, &
+               !    & kernel_idx, parameters)
+
+               ktmp = 0.0d0
+               call kernel(self_scalar1(a, i), self_scalar2(b, j), s12, &
+               & kernel_idx, parameters, ktmp)
+               kernels(:, a, b) = kernels(:, a, b) + ktmp
+
+            end do
+         end do
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (self_scalar2)
+   deallocate (ksi1)
+   deallocate (ksi2)
+   deallocate (cosp1)
+   deallocate (cosp2)
+   deallocate (sinp1)
+   deallocate (sinp2)
+
+end subroutine fget_kernels_fchl
+
+subroutine fget_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
+
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! FCHL descriptors for the training set, format (i,j_1,5,m_1)
+   double precision, dimension(:, :, :, :), intent(in) :: x1
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! List of numbers of atoms in each molecule
+   integer, dimension(:), intent(in) :: n1
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:, :), intent(in) :: nneigh1
+
+   ! Number of molecules
+   integer, intent(in) :: nm1
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+
+   logical, intent(in) :: alchemy
+   double precision, dimension(:, :), intent(in) :: pd
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, nm1, nm1), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j, ni, nj
+   integer :: a, b
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:, :) :: self_scalar1
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :, :) :: ksi1
+
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp1
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! counter for periodic distance
+   integer :: pmax1
+   ! integer :: nneighi
+
+   double precision :: ang_norm2
+
+   integer :: maxneigh1
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+
+   kernels(:, :, :) = 0.0d0
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   maxneigh1 = maxval(nneigh1)
+   pmax1 = get_pmax(x1, n1)
+
+   allocate (ksi1(size(x1, dim=1), maxval(n1), maxval(nneigh1)))
+   call get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   !ksi1 = get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+
+   allocate (cosp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+   allocate (sinp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+
+   call init_cosp_sinp(x1, n1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (self_scalar1(nm1, maxval(n1)))
+   call get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose, self_scalar1)
+   !self_scalar1 = get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   !     & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose)
+
+   allocate (ktmp(size(parameters, dim=1)))
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,ktmp)
+   do b = 1, nm1
+      nj = n1(b)
+      do a = b, nm1
+         ni = n1(a)
+
+         do i = 1, ni
+            do j = 1, nj
+
+               s12 = scalar(x1(a, i, :, :), x1(b, j, :, :), &
+               & nneigh1(a, i), nneigh1(b, j), ksi1(a, i, :), ksi1(b, j, :), &
+               & sinp1(a, i, :, :, :), sinp1(b, j, :, :, :), &
+               & cosp1(a, i, :, :, :), cosp1(b, j, :, :, :), &
+               & t_width, d_width, cut_distance, order, &
+               & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+               ktmp(:) = 0.0d0
+               call kernel(self_scalar1(a, i), self_scalar1(b, j), s12, &
+               & kernel_idx, parameters, ktmp)
+
+               kernels(:, a, b) = kernels(:, a, b) + ktmp
+               !kernels(:, a, b) = kernels(:, a, b) &
+               !    & + kernel(self_scalar1(a, i), self_scalar1(b, j), s12, &
+               !    & kernel_idx, parameters)
+
+               kernels(:, b, a) = kernels(:, a, b)
+
+            end do
+         end do
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (ksi1)
+   deallocate (cosp1)
+   deallocate (sinp1)
+
+end subroutine fget_symmetric_kernels_fchl
+
+subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! FCHL descriptors for the training set, format (i,j_1,5,m_1)
+   double precision, dimension(:, :, :, :), intent(in) :: x1
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! List of numbers of atoms in each molecule
+   integer, dimension(:), intent(in) :: n1
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:, :), intent(in) :: nneigh1
+
+   ! Number of molecules
+   integer, intent(in) :: nm1
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+   logical, intent(in) :: alchemy
+
+   double precision, dimension(:, :), intent(in) :: pd
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, nm1, nm1), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j, ni, nj
+   integer :: a, b
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:) :: self_scalar1
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :, :) :: ksi1
+
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp1
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! counter for periodic distance
+   integer :: pmax1
+
+   double precision :: ang_norm2
+
+   double precision :: mol_dist
+
+   integer :: maxneigh1
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+   allocate (ktmp(size(parameters, dim=1)))
+
+   maxneigh1 = maxval(nneigh1)
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   pmax1 = get_pmax(x1, n1)
+
+   !ksi1 = get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+   allocate (ksi1(size(x1, dim=1), maxval(n1), maxval(nneigh1)))
+   call get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+
+   allocate (cosp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+   allocate (sinp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+
+   call init_cosp_sinp(x1, n1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (self_scalar1(nm1))
+
+   self_scalar1 = 0.0d0
+
+   !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar1)
+   do a = 1, nm1
+      ni = n1(a)
+      do i = 1, ni
+         do j = 1, ni
+
+            self_scalar1(a) = self_scalar1(a) + scalar(x1(a, i, :, :), x1(a, j, :, :), &
+            & nneigh1(a, i), nneigh1(a, j), ksi1(a, i, :), ksi1(a, j, :), &
+            & sinp1(a, i, :, :, :), sinp1(a, j, :, :, :), &
+            & cosp1(a, i, :, :, :), cosp1(a, j, :, :, :), &
+            & t_width, d_width, cut_distance, order, &
+            & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+         end do
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   kernels(:, :, :) = 0.0d0
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,mol_dist,ktmp)
+   do b = 1, nm1
+      nj = n1(b)
+      do a = b, nm1
+         ni = n1(a)
+
+         mol_dist = 0.0d0
+
+         do i = 1, ni
+            do j = 1, nj
+
+               s12 = scalar(x1(a, i, :, :), x1(b, j, :, :), &
+               & nneigh1(a, i), nneigh1(b, j), ksi1(a, i, :), ksi1(b, j, :), &
+               & sinp1(a, i, :, :, :), sinp1(b, j, :, :, :), &
+               & cosp1(a, i, :, :, :), cosp1(b, j, :, :, :), &
+               & t_width, d_width, cut_distance, order, &
+               & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+               mol_dist = mol_dist + s12
+
+            end do
+         end do
+
+         ktmp = 0.0d0
+         call kernel(self_scalar1(a), self_scalar1(b), mol_dist, &
+         & kernel_idx, parameters, ktmp)
+         kernels(:, a, b) = ktmp
+         !kernels(:, a, b) = kernel(self_scalar1(a), self_scalar1(b), mol_dist, &
+         !    & kernel_idx, parameters)
+
+         kernels(:, b, a) = kernels(:, a, b)
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (ksi1)
+   deallocate (cosp1)
+   deallocate (sinp1)
+
+end subroutine fget_global_symmetric_kernels_fchl
+
+subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
+& nm1, nm2, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+   double precision, dimension(:, :, :, :), intent(in) :: x1
+   double precision, dimension(:, :, :, :), intent(in) :: x2
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! List of numbers of atoms in each molecule
+   integer, dimension(:), intent(in) :: n1
+   integer, dimension(:), intent(in) :: n2
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:, :), intent(in) :: nneigh1
+   integer, dimension(:, :), intent(in) :: nneigh2
+
+   ! Number of molecules
+   integer, intent(in) :: nm1
+   integer, intent(in) :: nm2
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+   logical, intent(in) :: alchemy
+
+   double precision, dimension(:, :), intent(in) :: pd
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, nm1, nm2), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j
+   integer :: ni, nj
+   integer :: a, b
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+   ! double precision, allocatable, dimension(:,:) :: atomic_distance
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:) :: self_scalar1
+   double precision, allocatable, dimension(:) :: self_scalar2
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :, :) :: ksi1
+   double precision, allocatable, dimension(:, :, :) :: ksi2
+
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp2
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp2
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! counter for periodic distance
+   integer :: pmax1
+   integer :: pmax2
+   ! integer :: nneighi
+   double precision :: ang_norm2
+
+   double precision :: mol_dist
+
+   integer :: maxneigh1
+   integer :: maxneigh2
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+   allocate (ktmp(size(parameters, dim=1)))
+
+   maxneigh1 = maxval(nneigh1)
+   maxneigh2 = maxval(nneigh2)
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   pmax1 = get_pmax(x1, n1)
+   pmax2 = get_pmax(x2, n2)
+
+   allocate (ksi1(size(x1, dim=1), maxval(n1), maxval(nneigh1)))
+   allocate (ksi2(size(x2, dim=1), maxval(n2), maxval(nneigh2)))
+   call get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   call get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose, ksi2)
+   !ksi1 = get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+   !ksi2 = get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose)
+
+   allocate (cosp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+   allocate (sinp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+
+   call init_cosp_sinp(x1, n1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (cosp2(nm2, maxval(n2), pmax2, order, maxval(nneigh2)))
+   allocate (sinp2(nm2, maxval(n2), pmax2, order, maxval(nneigh2)))
+
+   call init_cosp_sinp(x2, n2, nneigh2, three_body_power, order, cut_start, cut_distance, &
+   & cosp2, sinp2, verbose)
+
+   ! Global self-scalar have their own summation and are not a general function
+   allocate (self_scalar1(nm1))
+   allocate (self_scalar2(nm2))
+
+   self_scalar1 = 0.0d0
+   self_scalar2 = 0.0d0
+
+   !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar1)
+   do a = 1, nm1
+      ni = n1(a)
+      do i = 1, ni
+         do j = 1, ni
+
+            self_scalar1(a) = self_scalar1(a) + scalar(x1(a, i, :, :), x1(a, j, :, :), &
+            & nneigh1(a, i), nneigh1(a, j), ksi1(a, i, :), ksi1(a, j, :), &
+            & sinp1(a, i, :, :, :), sinp1(a, j, :, :, :), &
+            & cosp1(a, i, :, :, :), cosp1(a, j, :, :, :), &
+            & t_width, d_width, cut_distance, order, &
+            & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+         end do
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar2)
+   do a = 1, nm2
+      ni = n2(a)
+      do i = 1, ni
+         do j = 1, ni
+            self_scalar2(a) = self_scalar2(a) + scalar(x2(a, i, :, :), x2(a, j, :, :), &
+            & nneigh2(a, i), nneigh2(a, j), ksi2(a, i, :), ksi2(a, j, :), &
+            & sinp2(a, i, :, :, :), sinp2(a, j, :, :, :), &
+            & cosp2(a, i, :, :, :), cosp2(a, j, :, :, :), &
+            & t_width, d_width, cut_distance, order, &
+            & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+         end do
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   kernels(:, :, :) = 0.0d0
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,mol_dist,ktmp)
+   do b = 1, nm2
+      nj = n2(b)
+      do a = 1, nm1
+         ni = n1(a)
+
+         mol_dist = 0.0d0
+
+         do i = 1, ni
+            do j = 1, nj
+
+               s12 = scalar(x1(a, i, :, :), x2(b, j, :, :), &
+               & nneigh1(a, i), nneigh2(b, j), ksi1(a, i, :), ksi2(b, j, :), &
+               & sinp1(a, i, :, :, :), sinp2(b, j, :, :, :), &
+               & cosp1(a, i, :, :, :), cosp2(b, j, :, :, :), &
+               & t_width, d_width, cut_distance, order, &
+               & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+               mol_dist = mol_dist + s12
+
+            end do
+         end do
+
+         ktmp = 0.0d0
+         call kernel(self_scalar1(a), self_scalar2(b), mol_dist, &
+         & kernel_idx, parameters, ktmp)
+         kernels(:, a, b) = ktmp
+         !kernels(:, a, b) = kernel(self_scalar1(a), self_scalar2(b), mol_dist, &
+         !    & kernel_idx, parameters)
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (self_scalar2)
+   deallocate (ksi1)
+   deallocate (ksi2)
+   deallocate (cosp1)
+   deallocate (cosp2)
+   deallocate (sinp1)
+   deallocate (sinp2)
+
+end subroutine fget_global_kernels_fchl
+
+subroutine fget_atomic_kernels_fchl(x1, x2, verbose, nneigh1, nneigh2, &
+& na1, na2, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, &
+   & get_pmax_atomic, get_ksi_atomic, init_cosp_sinp_atomic
+
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+   double precision, dimension(:, :, :), intent(in) :: x1
+   double precision, dimension(:, :, :), intent(in) :: x2
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:), intent(in) :: nneigh1
+   integer, dimension(:), intent(in) :: nneigh2
+
+   ! Number of molecules
+   integer, intent(in) :: na1
+   integer, intent(in) :: na2
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+   logical, intent(in) :: alchemy
+
+   double precision, dimension(:, :), intent(in) :: pd
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, na1, na2), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:) :: self_scalar1
+   double precision, allocatable, dimension(:) :: self_scalar2
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :) :: ksi1
+   double precision, allocatable, dimension(:, :) :: ksi2
+
+   double precision, allocatable, dimension(:, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :) :: sinp2
+   double precision, allocatable, dimension(:, :, :, :) :: cosp1
+   double precision, allocatable, dimension(:, :, :, :) :: cosp2
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! counter for periodic distance
+   integer :: pmax1
+   integer :: pmax2
+   double precision :: ang_norm2
+
+   integer :: maxneigh1
+   integer :: maxneigh2
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+   allocate (ktmp(size(parameters, dim=1)))
+
+   maxneigh1 = maxval(nneigh1)
+   maxneigh2 = maxval(nneigh2)
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   pmax1 = get_pmax_atomic(x1, nneigh1)
+   pmax2 = get_pmax_atomic(x2, nneigh2)
+
+   allocate (ksi1(na1, maxval(nneigh1)))
+   allocate (ksi2(na2, maxval(nneigh2)))
+   call get_ksi_atomic(x1, na1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   call get_ksi_atomic(x2, na2, nneigh2, two_body_power, cut_start, cut_distance, verbose, ksi2)
+   !ksi1 = get_ksi_atomic(x1, na1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+   !ksi2 = get_ksi_atomic(x2, na2, nneigh2, two_body_power, cut_start, cut_distance, verbose)
+
+   allocate (cosp1(na1, pmax1, order, maxneigh1))
+   allocate (sinp1(na1, pmax1, order, maxneigh1))
+
+   call init_cosp_sinp_atomic(x1, na1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (cosp2(na2, pmax2, order, maxneigh2))
+   allocate (sinp2(na2, pmax2, order, maxneigh2))
+
+   call init_cosp_sinp_atomic(x2, na2, nneigh2, three_body_power, order, cut_start, cut_distance, &
+   & cosp2, sinp2, verbose)
+
+   allocate (self_scalar1(na1))
+   allocate (self_scalar2(na2))
+
+   self_scalar1 = 0.0d0
+   self_scalar2 = 0.0d0
+
+   !$OMP PARALLEL DO
+   do i = 1, na1
+      self_scalar1(i) = scalar(x1(i, :, :), x1(i, :, :), &
+      & nneigh1(i), nneigh1(i), ksi1(i, :), ksi1(i, :), &
+      & sinp1(i, :, :, :), sinp1(i, :, :, :), &
+      & cosp1(i, :, :, :), cosp1(i, :, :, :), &
+      & t_width, d_width, cut_distance, order, &
+      & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+   end do
+   !$OMP END PARALLEL DO
+
+   !$OMP PARALLEL DO
+   do i = 1, na2
+      self_scalar2(i) = scalar(x2(i, :, :), x2(i, :, :), &
+      & nneigh2(i), nneigh2(i), ksi2(i, :), ksi2(i, :), &
+      & sinp2(i, :, :, :), sinp2(i, :, :, :), &
+      & cosp2(i, :, :, :), cosp2(i, :, :, :), &
+      & t_width, d_width, cut_distance, order, &
+      & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+   end do
+   !$OMP END PARALLEL DO
+
+   kernels(:, :, :) = 0.0d0
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12, ktmp)
+   do i = 1, na1
+      do j = 1, na2
+
+         s12 = scalar(x1(i, :, :), x2(j, :, :), &
+         & nneigh1(i), nneigh2(j), ksi1(i, :), ksi2(j, :), &
+         & sinp1(i, :, :, :), sinp2(j, :, :, :), &
+         & cosp1(i, :, :, :), cosp2(j, :, :, :), &
+         & t_width, d_width, cut_distance, order, &
+         & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+         ktmp = 0.0d0
+         call kernel(self_scalar1(i), self_scalar2(j), s12, &
+         & kernel_idx, parameters, ktmp)
+         kernels(:, i, j) = ktmp
+         !kernels(:, i, j) = kernel(self_scalar1(i), self_scalar2(j), s12, &
+         !        & kernel_idx, parameters)
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (self_scalar2)
+   deallocate (ksi1)
+   deallocate (ksi2)
+   deallocate (cosp1)
+   deallocate (cosp2)
+   deallocate (sinp1)
+   deallocate (sinp2)
+
+end subroutine fget_atomic_kernels_fchl
+
+subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_angular_norm2, &
+   & get_pmax_atomic, get_ksi_atomic, init_cosp_sinp_atomic
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+   double precision, dimension(:, :, :), intent(in) :: x1
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:), intent(in) :: nneigh1
+
+   ! Number of molecules
+   integer, intent(in) :: na1
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+   logical, intent(in) :: alchemy
+
+   double precision, dimension(:, :), intent(in) :: pd
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, na1, na1), intent(out) :: kernels
+
+   ! Internal counters
+   integer :: i, j
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:) :: self_scalar1
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :) :: ksi1
+
+   double precision, allocatable, dimension(:, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :) :: cosp1
+
+   ! counter for periodic distance
+   integer :: pmax1
+   double precision :: ang_norm2
+
+   integer :: maxneigh1
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+   allocate (ktmp(size(parameters, dim=1)))
+
+   maxneigh1 = maxval(nneigh1)
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   pmax1 = get_pmax_atomic(x1, nneigh1)
+
+   allocate (ksi1(na1, maxval(nneigh1)))
+   call get_ksi_atomic(x1, na1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   !ksi1 = get_ksi_atomic(x1, na1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+
+   allocate (cosp1(na1, pmax1, order, maxneigh1))
+   allocate (sinp1(na1, pmax1, order, maxneigh1))
+
+   call init_cosp_sinp_atomic(x1, na1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (self_scalar1(na1))
+
+   self_scalar1 = 0.0d0
+
+   !$OMP PARALLEL DO
+   do i = 1, na1
+      self_scalar1(i) = scalar(x1(i, :, :), x1(i, :, :), &
+      & nneigh1(i), nneigh1(i), ksi1(i, :), ksi1(i, :), &
+      & sinp1(i, :, :, :), sinp1(i, :, :, :), &
+      & cosp1(i, :, :, :), cosp1(i, :, :, :), &
+      & t_width, d_width, cut_distance, order, &
+      & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+   end do
+   !$OMP END PARALLEL DO
+
+   kernels(:, :, :) = 0.0d0
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12, ktmp)
+   do i = 1, na1
+      do j = i, na1
+
+         s12 = scalar(x1(i, :, :), x1(j, :, :), &
+         & nneigh1(i), nneigh1(j), ksi1(i, :), ksi1(j, :), &
+         & sinp1(i, :, :, :), sinp1(j, :, :, :), &
+         & cosp1(i, :, :, :), cosp1(j, :, :, :), &
+         & t_width, d_width, cut_distance, order, &
+         & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+         !kernels(:, i, j) = kernel(self_scalar1(i), self_scalar1(j), s12, &
+         !        & kernel_idx, parameters)
+
+         ktmp = 0.0d0
+         call kernel(self_scalar1(i), self_scalar1(j), s12, &
+         & kernel_idx, parameters, ktmp)
+
+         kernels(:, i, j) = ktmp
+         kernels(:, j, i) = kernels(:, i, j)
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (ksi1)
+   deallocate (cosp1)
+   deallocate (sinp1)
+
+end subroutine fget_atomic_symmetric_kernels_fchl
+
+subroutine fget_atomic_local_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
+& nm1, nm2, na1, nsigmas, &
+& t_width, d_width, cut_start, cut_distance, order, pd, &
+& distance_scale, angular_scale, alchemy, two_body_power, three_body_power, &
+& kernel_idx, parameters, kernels)
+
+   use ffchl_module, only: scalar, get_threebody_fourier, get_twobody_weights, &
+   & get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
+   use ffchl_kernels, only: kernel
+
+   implicit none
+
+   ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
+   double precision, dimension(:, :, :, :), intent(in) :: x1
+   double precision, dimension(:, :, :, :), intent(in) :: x2
+
+   ! Whether to be verbose with output
+   logical, intent(in) :: verbose
+
+   ! List of numbers of atoms in each molecule
+   integer, dimension(:), intent(in) :: n1
+   integer, dimension(:), intent(in) :: n2
+
+   ! Number of neighbors for each atom in each compound
+   integer, dimension(:, :), intent(in) :: nneigh1
+   integer, dimension(:, :), intent(in) :: nneigh2
+
+   ! Number of molecules
+   integer, intent(in) :: nm1
+   integer, intent(in) :: nm2
+
+   integer, intent(in) :: na1
+
+   ! Number of sigmas
+   integer, intent(in) :: nsigmas
+
+   double precision, intent(in) :: two_body_power
+   double precision, intent(in) :: three_body_power
+
+   double precision, intent(in) :: t_width
+   double precision, intent(in) :: d_width
+   double precision, intent(in) :: cut_start
+   double precision, intent(in) :: cut_distance
+   integer, intent(in) :: order
+   double precision, intent(in) :: distance_scale
+   double precision, intent(in) :: angular_scale
+
+   ! -1.0 / sigma^2 for use in the kernel
+
+   double precision, dimension(:, :), intent(in) :: pd
+
+   integer, intent(in) :: kernel_idx
+   double precision, dimension(:, :), intent(in) :: parameters
+
+   ! Resulting alpha vector
+   double precision, dimension(nsigmas, na1, nm2), intent(out) :: kernels
+
+   integer :: idx1
+
+   ! Internal counters
+   integer :: i, j
+   integer :: ni, nj
+   integer :: a, b
+
+   ! Temporary variables necessary for parallelization
+   double precision :: s12
+
+   ! Pre-computed terms in the full distance matrix
+   double precision, allocatable, dimension(:, :) :: self_scalar1
+   double precision, allocatable, dimension(:, :) :: self_scalar2
+
+   ! Pre-computed terms
+   double precision, allocatable, dimension(:, :, :) :: ksi1
+   double precision, allocatable, dimension(:, :, :) :: ksi2
+
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: sinp2
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp1
+   double precision, allocatable, dimension(:, :, :, :, :) :: cosp2
+
+   logical, intent(in) :: alchemy
+
+   ! Value of PI at full FORTRAN precision.
+   double precision, parameter :: pi = 4.0d0*atan(1.0d0)
+
+   ! counter for periodic distance
+   integer :: pmax1
+   integer :: pmax2
+   ! integer :: nneighi
+
+   double precision :: ang_norm2
+
+   integer :: maxneigh1
+   integer :: maxneigh2
+
+   ! Work kernel
+   double precision, allocatable, dimension(:) :: ktmp
+   allocate (ktmp(size(parameters, dim=1)))
+
+   maxneigh1 = maxval(nneigh1)
+   maxneigh2 = maxval(nneigh2)
+
+   ang_norm2 = get_angular_norm2(t_width)
+
+   pmax1 = get_pmax(x1, n1)
+   pmax2 = get_pmax(x2, n2)
+
+   allocate (ksi1(size(x1, dim=1), maxval(n1), maxval(nneigh1)))
+   allocate (ksi2(size(x2, dim=1), maxval(n2), maxval(nneigh2)))
+   call get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose, ksi1)
+   call get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose, ksi2)
+   !ksi1 = get_ksi(x1, n1, nneigh1, two_body_power, cut_start, cut_distance, verbose)
+   !ksi2 = get_ksi(x2, n2, nneigh2, two_body_power, cut_start, cut_distance, verbose)
+
+   allocate (cosp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+   allocate (sinp1(nm1, maxval(n1), pmax1, order, maxval(nneigh1)))
+
+   call init_cosp_sinp(x1, n1, nneigh1, three_body_power, order, cut_start, cut_distance, &
+   & cosp1, sinp1, verbose)
+
+   allocate (cosp2(nm2, maxval(n2), pmax2, order, maxval(nneigh2)))
+   allocate (sinp2(nm2, maxval(n2), pmax2, order, maxval(nneigh2)))
+
+   call init_cosp_sinp(x2, n2, nneigh2, three_body_power, order, cut_start, cut_distance, &
+   & cosp2, sinp2, verbose)
+
+   ! Pre-calculate self-scalar terms
+   allocate (self_scalar1(nm1, maxval(n1)))
+   allocate (self_scalar2(nm2, maxval(n2)))
+   call get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose, self_scalar1)
+   call get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
+   & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose, self_scalar2)
+   !self_scalar1 = get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
+   !     & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose)
+
+   ! Pre-calculate self-scalar terms
+   !self_scalar2 = get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
+   !     & cut_distance, order, pd, ang_norm2, distance_scale, angular_scale, alchemy, verbose)
+
+   kernels(:, :, :) = 0.0d0
+
+   !$OMP PARALLEL DO schedule(dynamic) PRIVATE(ni,nj,idx1,s12,ktmp)
+   do a = 1, nm1
+      ni = n1(a)
+      do i = 1, ni
+
+         idx1 = sum(n1(:a)) - ni + i
+
+         do b = 1, nm2
+            nj = n2(b)
+            do j = 1, nj
+
+               s12 = scalar(x1(a, i, :, :), x2(b, j, :, :), &
+               & nneigh1(a, i), nneigh2(b, j), ksi1(a, i, :), ksi2(b, j, :), &
+               & sinp1(a, i, :, :, :), sinp2(b, j, :, :, :), &
+               & cosp1(a, i, :, :, :), cosp2(b, j, :, :, :), &
+               & t_width, d_width, cut_distance, order, &
+               & pd, ang_norm2, distance_scale, angular_scale, alchemy)
+
+               ktmp = 0.0d0
+               call kernel(self_scalar1(a, i), self_scalar2(b, j), s12, &
+               & kernel_idx, parameters, ktmp)
+               kernels(:, idx1, b) = kernels(:, idx1, b) + ktmp
+
+               !kernels(:, idx1, b) = kernels(:, idx1, b) &
+               !    & + kernel(self_scalar1(a, i), self_scalar2(b, j), s12, &
+               !    & kernel_idx, parameters)
+
+            end do
+         end do
+
+      end do
+   end do
+   !$OMP END PARALLEL DO
+
+   deallocate (ktmp)
+   deallocate (self_scalar1)
+   deallocate (self_scalar2)
+   deallocate (ksi1)
+   deallocate (ksi2)
+   deallocate (cosp1)
+   deallocate (cosp2)
+   deallocate (sinp1)
+   deallocate (sinp2)
+
+end subroutine fget_atomic_local_kernels_fchl

--- a/JKML/src/load_databases.py
+++ b/JKML/src/load_databases.py
@@ -1,61 +1,94 @@
-def load_databases(Qtrain, Qeval, Qopt, Qmonomers, method, VARS_PKL, TRAIN_HIGH, TRAIN_LOW, TEST_HIGH, TEST_LOW, MONOMERS_HIGH, MONOMERS_LOW):
+def load_databases(
+    Qtrain,
+    Qeval,
+    Qopt,
+    Qmonomers,
+    Qhyper,
+    method,
+    VARS_PKL,
+    TRAIN_HIGH,
+    TRAIN_LOW,
+    TEST_HIGH,
+    TEST_LOW,
+    MONOMERS_HIGH,
+    MONOMERS_LOW,
+):
 
-  import os
-  from pandas import read_pickle
+    import os
+    from pandas import read_pickle
 
-  if Qtrain == 1:
-    if not os.path.exists(TRAIN_HIGH):
-      print("Error reading file. TRAIN_HIGH = "+TRAIN_HIGH)
-      exit()
-    if method == "delta":
-      if not os.path.exists(TRAIN_LOW):
-        print("Error reading file. TRAIN_LOW = "+TRAIN_LOW)
-        exit()
-  if Qtrain == 2:
-    if not os.path.exists(VARS_PKL):
-      print("Error reading file. VARS_PKL = "+VARS_PKL)
-      exit()
-  if Qeval == 1 or Qeval == 2:
-    if not os.path.exists(TEST_HIGH):
-      print("Error reading file. + TEST_HIGH = "+TEST_HIGH)
-      exit()
-    if method == "delta":
-      if not os.path.exists(TEST_LOW):
-        if Qeval == 1:
-          TEST_LOW = TEST_HIGH
-        else:
-          print("Error reading file. + TEST_LOW = "+TEST_LOW)
-          exit()
-  if Qmonomers == 1:
-    if not os.path.exists(MONOMERS_HIGH):
-      print("Error reading file. MONOMERS_HIGH = "+MONOMERS_HIGH)
-      exit()
-    if method == "delta":
-      if not os.path.exists(MONOMERS_LOW):
-        print("Error reading file. MONOMERS_LOW = "+MONOMERS_LOW)
-        exit()
-  
-  #IMPORTING THE REST OF LIBRARIES
-  print("JKML is loading database(s).", flush=True)
-  
-  #LOADING THE DATABASES
-  train_high_database = "none"
-  train_low_database = "none"
-  test_high_database = "none"
-  test_low_database = "none"
-  monomers_high_database = "none"
-  monomers_low_database = "none"
-  if Qtrain == 1:
-    train_high_database = read_pickle(TRAIN_HIGH).sort_values([('info','file_basename')])
-    if method == "delta":
-      train_low_database = read_pickle(TRAIN_LOW).sort_values([('info','file_basename')])
-  if Qeval == 1 or Qeval == 2 or Qopt > 0:
-    test_high_database = read_pickle(TEST_HIGH).sort_values([('info','file_basename')])
-    if method == "delta":
-      test_low_database = read_pickle(TEST_LOW).sort_values([('info','file_basename')])
-  if Qmonomers == 1:
-    monomers_high_database = read_pickle(MONOMERS_HIGH).sort_values([('info','file_basename')])
-    if method == "delta":
-      monomers_low_database = read_pickle(MONOMERS_LOW).sort_values([('info','file_basename')])
+    if Qtrain == 1 or Qhyper:
+        if not os.path.exists(TRAIN_HIGH):
+            print("Error reading file. TRAIN_HIGH = " + TRAIN_HIGH)
+            exit()
+        if method == "delta":
+            if not os.path.exists(TRAIN_LOW):
+                print("Error reading file. TRAIN_LOW = " + TRAIN_LOW)
+                exit()
+    if Qtrain == 2:
+        if not os.path.exists(VARS_PKL):
+            print("Error reading file. VARS_PKL = " + VARS_PKL)
+            exit()
+    if Qeval == 1 or Qeval == 2:
+        if not os.path.exists(TEST_HIGH):
+            print("Error reading file. + TEST_HIGH = " + TEST_HIGH)
+            exit()
+        if method == "delta":
+            if not os.path.exists(TEST_LOW):
+                if Qeval == 1:
+                    TEST_LOW = TEST_HIGH
+                else:
+                    print("Error reading file. + TEST_LOW = " + TEST_LOW)
+                    exit()
+    if Qmonomers == 1:
+        if not os.path.exists(MONOMERS_HIGH):
+            print("Error reading file. MONOMERS_HIGH = " + MONOMERS_HIGH)
+            exit()
+        if method == "delta":
+            if not os.path.exists(MONOMERS_LOW):
+                print("Error reading file. MONOMERS_LOW = " + MONOMERS_LOW)
+                exit()
 
-  return train_high_database, train_low_database, test_high_database, test_low_database, monomers_high_database, monomers_low_database
+    # IMPORTING THE REST OF LIBRARIES
+    print("JKML is loading database(s).", flush=True)
+
+    # LOADING THE DATABASES
+    train_high_database = "none"
+    train_low_database = "none"
+    test_high_database = "none"
+    test_low_database = "none"
+    monomers_high_database = "none"
+    monomers_low_database = "none"
+    if Qtrain == 1 or Qhyper:
+        train_high_database = read_pickle(TRAIN_HIGH).sort_values(
+            [("info", "file_basename")]
+        )
+        if method == "delta":
+            train_low_database = read_pickle(TRAIN_LOW).sort_values(
+                [("info", "file_basename")]
+            )
+    if Qeval == 1 or Qeval == 2 or Qopt > 0:
+        test_high_database = read_pickle(TEST_HIGH).sort_values(
+            [("info", "file_basename")]
+        )
+        if method == "delta":
+            test_low_database = read_pickle(TEST_LOW).sort_values(
+                [("info", "file_basename")]
+            )
+    if Qmonomers == 1:
+        monomers_high_database = read_pickle(MONOMERS_HIGH).sort_values(
+            [("info", "file_basename")]
+        )
+        if method == "delta":
+            monomers_low_database = read_pickle(MONOMERS_LOW).sort_values(
+                [("info", "file_basename")]
+            )
+
+    return (
+        train_high_database,
+        train_low_database,
+        test_high_database,
+        test_low_database,
+        monomers_high_database,
+        monomers_low_database,
+    )

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -298,6 +298,7 @@ def print_results(
     clustersout_df.loc[:, ("extra", "d_test")] = d_test
 
     clustersout_df.to_pickle(outfile)
+    print(f"Saved results to {outfile}", flush=True)
     if Qsampleeach > 0:
         if sampleeach_i == 0:
             os.system("JKQC " + outfile + " -out predicted_QML_FULL.pkl -noex")

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -281,18 +281,18 @@ def print_results(
                 array(force) for force in F_predicted[0][i]
             ]
     ### SAVE TIME AND SHAPE INFORMATION
-    clusters_df.loc[:, ("extra", "repr_train_wall")] = repr_train_wall
-    clusters_df.loc[:, ("extra", "repr_train_cpu")] = repr_train_cpu
-    clusters_df.loc[:, ("extra", "repr_test_wall")] = repr_test_wall
-    clusters_df.loc[:, ("extra", "repr_test_cpu")] = repr_test_cpu
-    clusters_df.loc[:, ("extra", "train_wall")] = train_wall
-    clusters_df.loc[:, ("extra", "train_cpu")] = train_cpu
-    clusters_df.loc[:, ("extra", "test_wall")] = test_wall
-    clusters_df.loc[:, ("extra", "test_cpu")] = test_cpu
-    clusters_df.loc[:, ("extra", "n_train")] = n_train
-    clusters_df.loc[:, ("extra", "d_train")] = d_train
-    clusters_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[0]
-    clusters_df.loc[:, ("extra", "d_test")] = d_test
+    clustersout_df.loc[:, ("extra", "repr_train_wall")] = repr_train_wall
+    clustersout_df.loc[:, ("extra", "repr_train_cpu")] = repr_train_cpu
+    clustersout_df.loc[:, ("extra", "repr_test_wall")] = repr_test_wall
+    clustersout_df.loc[:, ("extra", "repr_test_cpu")] = repr_test_cpu
+    clustersout_df.loc[:, ("extra", "train_wall")] = train_wall
+    clustersout_df.loc[:, ("extra", "train_cpu")] = train_cpu
+    clustersout_df.loc[:, ("extra", "test_wall")] = test_wall
+    clustersout_df.loc[:, ("extra", "test_cpu")] = test_cpu
+    clustersout_df.loc[:, ("extra", "n_train")] = n_train
+    clustersout_df.loc[:, ("extra", "d_train")] = d_train
+    clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[0]
+    clustersout_df.loc[:, ("extra", "d_test")] = d_test
 
     clustersout_df.to_pickle(outfile)
     if Qsampleeach > 0:

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -292,7 +292,7 @@ def print_results(
     clustersout_df.loc[:, ("extra", "n_train")] = n_train
     clustersout_df.loc[:, ("extra", "d_train")] = d_train
     if isinstance(Y_predicted, list):
-        clustersout_df.loc[:, ("extra", "n_test")] = len(Y_predicted)
+        clustersout_df.loc[:, ("extra", "n_test")] = array(Y_predicted).shape[1]
     elif isinstance(Y_predicted, ndarray):
         clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[1]
     clustersout_df.loc[:, ("extra", "d_test")] = d_test

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -1,133 +1,308 @@
 def flatten(matrix):
-  from numpy import array
-  return array([item for row in matrix for item in row])
+    from numpy import array
 
-def print_results(clusters_df, Y_predicted, Y_validation, F_predicted, F_test, ens, ens_correction, form_ens, ens2, ens2_correction, form_ens2, method, Qeval, Qforces, Qwolfram, Qprintforces, outfile, sampleeach_i, Qsampleeach, column_name_1, column_name_2, clustersout_df, sigmas, Qcharge, Q_charges, Qa_predicted):
+    return array([item for row in matrix for item in row])
 
-  from numpy import array, isnan, mean, std, abs, sqrt, median    
-  
-  if Qwolfram == 0:
-    lb = "["; rb = "]"
-  else:
-    lb = "{"; rb = "}"
 
-  print("\n########   RESULTS   #########\n")  
+def print_results(
+    clusters_df,
+    Y_predicted,
+    Y_validation,
+    F_predicted,
+    F_test,
+    ens,
+    ens_correction,
+    form_ens,
+    ens2,
+    ens2_correction,
+    form_ens2,
+    method,
+    Qeval,
+    Qforces,
+    Qwolfram,
+    Qprintforces,
+    outfile,
+    sampleeach_i,
+    Qsampleeach,
+    column_name_1,
+    column_name_2,
+    clustersout_df,
+    sigmas,
+    Qcharge,
+    Q_charges,
+    Qa_predicted,
+    repr_train_wall,
+    repr_train_cpu,
+    repr_test_wall,
+    repr_test_cpu,
+    train_wall,
+    train_cpu,
+    test_wall,
+    test_cpu,
+    n_train,
+    d_train,
+    d_test,
+):
 
-  ### PRINT THE PROPERTIES ###
-  if Qeval == 2:
-    print("Ytest = " + lb + ",".join([str(i) for i in ens]) + rb + ";", flush = True)
-  if method != "delta":
-    print("Ypredicted = "+ lb + ",".join([str(i) for i in Y_predicted[0]+ens_correction])+rb+";", flush = True)
-  else:
-    print("Ypredicted = "+ lb + ",".join([str(i) for i in Y_predicted[0]+form_ens2+ens_correction])+rb+";", flush = True)
-  
-  ### PRINT THE FORCES
-  if Qforces == 1:
-    if Qprintforces == 0:
-      if Qeval == 2:
-        print("Ftest = I will not print the forces becuase it would be too many numbers. (Use -printforces)", flush = True)
-      print("Fpredicted = I will not print the forces becuase it would be too many numbers. (Use -printforces)", flush = True)
+    from numpy import array, isnan, mean, std, abs, sqrt, median
+
+    if Qwolfram == 0:
+        lb = "["
+        rb = "]"
     else:
-      if Qeval == 2:
-        print("Fpredicted = "+lb + ",".join([lb+",".join([lb+",".join([str(k) for k in j])+rb for j in i])+rb for i in F_predicted[0]])+rb+";", flush = True)
-      print("Ftest = " + lb + ",".join([lb+",".join([lb+",".join([str(k) for k in j])+rb for j in i])+rb for i in F_test])+rb+";", flush = True)
+        lb = "{"
+        rb = "}"
 
-  ### PRINT THE STATISTICS
-  # If possible print MAE and RMSE of energies and forces
-  if Qeval == 2:
-    ### Kick-out nans
-    err = len(Y_predicted[0][isnan(Y_predicted[0])])
-    if err > 0:
-      print("\nERROR: "+str(err)+" NaNs in the predicted set.\nThose have been removed from statistics.\n", flush = True)
-      valid_indices = ~isnan(Y_predicted[0])
-      Y_validation_rem = Y_validation
-      Y_validation = Y_validation[valid_indices]
-      Y_predicted_rem = Y_predicted
-      Y_predicted = [Y_predicted[0][valid_indices]]
-      if Qforces == 1:
-        F_predicted_rem = F_predicted
-        F_predicted = [list(array(F_predicted[0])[valid_indices])]
-        F_test = list(array(F_test)[valid_indices])
-    ### Calculate mean-absolute-error (MAE):
-    if column_name_1 == "log" and column_name_2 == "electronic_energy":
-      multiplier = 627.503
-      units = " kcal/mol"
-    else:
-      multiplier = 1.0
-      units = " [?]"
-    print("", flush = True)
-    print("Results:", flush = True)
-    mae = [multiplier*mean(abs(Y_predicted[i] - Y_validation))  for i in range(len(sigmas))]
-    sd = [multiplier*std(abs(Y_predicted[i] - Y_validation))  for i in range(len(sigmas))]
-    print("Mean Absolute Error:", flush = True)
-    print("mae = " + ",".join([str(i) for i in mae])+units+"(+- "+str(sd[0])+" )", flush = True)
-    ### Calculate root-mean-squared-error (RMSE):
-    rmse = [multiplier*sqrt(mean(abs(Y_predicted[i] - Y_validation)**2))  for i in range(len(sigmas))]
-    print("Root Mean Squared Error", flush = True)
-    print("rmse = " + ",".join([str(i) for i in rmse])+units, flush = True)
-    ### Calculate mean-absolute-relative-error (MArE):
-    diff = [mean(Y_predicted[i]) - mean(Y_validation) for i in range(len(sigmas))]
-    mare = [multiplier*mean(abs(Y_predicted[i] - Y_validation - diff[i]))  for i in range(len(sigmas))]
-    print("Mean Absolute (mean-)Relative Error:", flush = True)
-    print("mare = " + ",".join([str(i) for i in mare])+units, flush = True)
-    ### Calculate root-mean-squared-relative-error (RMSrE):
-    rmsre = [multiplier*sqrt(mean(abs(Y_predicted[i] - Y_validation - diff[i])**2))  for i in range(len(sigmas))]
-    print("Root Mean Squared (mean-)Relative Error", flush = True)
-    print("rmsre = " + ",".join([str(i) for i in rmsre])+units, flush = True)
-    diff = [median(Y_predicted[i]) - median(Y_validation) for i in range(len(sigmas))]
-    mare = [multiplier*mean(abs(Y_predicted[i] - Y_validation - diff[i]))  for i in range(len(sigmas))]
-    print("Mean Absolute (median-)Relative Error:", flush = True)
-    print("mare = " + ",".join([str(i) for i in mare])+units, flush = True)
-    ### Calculate root-mean-squared-relative-error (RMSrE):
-    rmsre = [multiplier*sqrt(mean(abs(Y_predicted[i] - Y_validation - diff[i])**2))  for i in range(len(sigmas))]
-    print("Root Mean Squared (median-)Relative Error", flush = True)
-    print("rmsre = " + ",".join([str(i) for i in rmsre])+units, flush = True)
+    print("\n########   RESULTS   #########\n")
 
-    if Qforces == 1:
-      multiplier = 627.503
-      units = " [kcal/mol/Angstrom]"
-      print("", flush = True)
-      print("Results for forces:", flush = True)
-      mae = [multiplier*mean(abs(flatten(F_predicted[i]) - flatten(F_test))) for i in range(len(sigmas))]
-      std = [multiplier*std(abs(flatten(F_predicted[i]) - flatten(F_test))) for i in range(len(sigmas))]
-      print("MAE = " + ",".join([str(i) for i in mae])+units+"(+- "+str(std[0])+" )", flush = True)
-      rmse = [multiplier*sqrt(mean(abs(flatten(F_predicted[i]) - flatten(F_test))**2))  for i in range(len(sigmas))]
-      print("RMSE = " + ",".join([str(i) for i in rmse])+units, flush = True)
-
-    if Qcharge == 1:
-      print("", flush = True)
-      print("Results for charges:", flush = True)
-      Qa_predicted = flatten(array([flatten(array(i)) for i in Qa_predicted]))
-      Q_charges = flatten(array([array(i) for i in Q_charges]))
-      mae = [mean(abs(Qa_predicted - Q_charges))]
-      print("MAE = " + ",".join([str(i) for i in mae])+" e", flush = True)
-      rmse = [sqrt(mean(abs(Qa_predicted - Q_charges)**2))]
-      print("RMSE = " + ",".join([str(i) for i in rmse])+" e", flush = True)
-
-    if err > 0:
-      Y_predicted = Y_predicted_rem
-      Y_validation = Y_validation_rem
-      if Qforces == 1:
-        F_predicted = F_predicted_rem
-
-  ### PRINTING THE QML PICKLES
-  for i in range(len(clustersout_df)):
-    if method != "delta":
-      clustersout_df.loc[clustersout_df.iloc[i].name,(column_name_1,column_name_2)] = Y_predicted[0][i]+ens_correction[i]
-    else:
-      clustersout_df.loc[clustersout_df.iloc[i].name,(column_name_1,column_name_2)] = Y_predicted[0][i]+form_ens2[i]+ens_correction[i]
+    ### PRINT THE PROPERTIES ###
     if Qeval == 2:
-      clustersout_df.loc[clustersout_df.iloc[i].name,("extra","error")] = multiplier*abs(Y_predicted[0][i] - Y_validation[i])
-    if Qforces == 1:
-      if ("extra","forces") not in clustersout_df.columns:
-        #clustersout_df.loc[clustersout_df.iloc[i].name,("extra","forces")] = [array(force) for force in F_predicted[0][i]]
-        clustersout_df.loc[:,("extra","forces")] = None
-      clustersout_df.at[clustersout_df.iloc[i].name,("extra","forces")] = [array(force) for force in F_predicted[0][i]]
-  clustersout_df.to_pickle(outfile)
-  if Qsampleeach > 0:
-    if sampleeach_i == 0:
-      os.system("JKQC "+outfile+" -out predicted_QML_FULL.pkl -noex")
+        print("Ytest = " + lb + ",".join([str(i) for i in ens]) + rb + ";", flush=True)
+    if method != "delta":
+        print(
+            "Ypredicted = "
+            + lb
+            + ",".join([str(i) for i in Y_predicted[0] + ens_correction])
+            + rb
+            + ";",
+            flush=True,
+        )
     else:
-      os.system("JKQC "+outfile+" predicted_QML_FULL.pkl -out predicted_QML_FULL.pkl -noex")
- 
-  return
+        print(
+            "Ypredicted = "
+            + lb
+            + ",".join([str(i) for i in Y_predicted[0] + form_ens2 + ens_correction])
+            + rb
+            + ";",
+            flush=True,
+        )
+
+    ### PRINT THE FORCES
+    if Qforces == 1:
+        if Qprintforces == 0:
+            if Qeval == 2:
+                print(
+                    "Ftest = I will not print the forces becuase it would be too many numbers. (Use -printforces)",
+                    flush=True,
+                )
+            print(
+                "Fpredicted = I will not print the forces becuase it would be too many numbers. (Use -printforces)",
+                flush=True,
+            )
+        else:
+            if Qeval == 2:
+                print(
+                    "Fpredicted = "
+                    + lb
+                    + ",".join(
+                        [
+                            lb
+                            + ",".join(
+                                [lb + ",".join([str(k) for k in j]) + rb for j in i]
+                            )
+                            + rb
+                            for i in F_predicted[0]
+                        ]
+                    )
+                    + rb
+                    + ";",
+                    flush=True,
+                )
+            print(
+                "Ftest = "
+                + lb
+                + ",".join(
+                    [
+                        lb
+                        + ",".join([lb + ",".join([str(k) for k in j]) + rb for j in i])
+                        + rb
+                        for i in F_test
+                    ]
+                )
+                + rb
+                + ";",
+                flush=True,
+            )
+
+    ### PRINT THE STATISTICS
+    # If possible print MAE and RMSE of energies and forces
+    if Qeval == 2:
+        ### Kick-out nans
+        err = len(Y_predicted[0][isnan(Y_predicted[0])])
+        if err > 0:
+            print(
+                "\nERROR: "
+                + str(err)
+                + " NaNs in the predicted set.\nThose have been removed from statistics.\n",
+                flush=True,
+            )
+            valid_indices = ~isnan(Y_predicted[0])
+            Y_validation_rem = Y_validation
+            Y_validation = Y_validation[valid_indices]
+            Y_predicted_rem = Y_predicted
+            Y_predicted = [Y_predicted[0][valid_indices]]
+            if Qforces == 1:
+                F_predicted_rem = F_predicted
+                F_predicted = [list(array(F_predicted[0])[valid_indices])]
+                F_test = list(array(F_test)[valid_indices])
+        ### Calculate mean-absolute-error (MAE):
+        if column_name_1 == "log" and column_name_2 == "electronic_energy":
+            multiplier = 627.503
+            units = " kcal/mol"
+        else:
+            multiplier = 1.0
+            units = " [?]"
+        print("", flush=True)
+        print("Results:", flush=True)
+        mae = [
+            multiplier * mean(abs(Y_predicted[i] - Y_validation))
+            for i in range(len(sigmas))
+        ]
+        sd = [
+            multiplier * std(abs(Y_predicted[i] - Y_validation))
+            for i in range(len(sigmas))
+        ]
+        print("Mean Absolute Error:", flush=True)
+        print(
+            "mae = "
+            + ",".join([str(i) for i in mae])
+            + units
+            + "(+- "
+            + str(sd[0])
+            + " )",
+            flush=True,
+        )
+        ### Calculate root-mean-squared-error (RMSE):
+        rmse = [
+            multiplier * sqrt(mean(abs(Y_predicted[i] - Y_validation) ** 2))
+            for i in range(len(sigmas))
+        ]
+        print("Root Mean Squared Error", flush=True)
+        print("rmse = " + ",".join([str(i) for i in rmse]) + units, flush=True)
+        ### Calculate mean-absolute-relative-error (MArE):
+        diff = [mean(Y_predicted[i]) - mean(Y_validation) for i in range(len(sigmas))]
+        mare = [
+            multiplier * mean(abs(Y_predicted[i] - Y_validation - diff[i]))
+            for i in range(len(sigmas))
+        ]
+        print("Mean Absolute (mean-)Relative Error:", flush=True)
+        print("mare = " + ",".join([str(i) for i in mare]) + units, flush=True)
+        ### Calculate root-mean-squared-relative-error (RMSrE):
+        rmsre = [
+            multiplier * sqrt(mean(abs(Y_predicted[i] - Y_validation - diff[i]) ** 2))
+            for i in range(len(sigmas))
+        ]
+        print("Root Mean Squared (mean-)Relative Error", flush=True)
+        print("rmsre = " + ",".join([str(i) for i in rmsre]) + units, flush=True)
+        diff = [
+            median(Y_predicted[i]) - median(Y_validation) for i in range(len(sigmas))
+        ]
+        mare = [
+            multiplier * mean(abs(Y_predicted[i] - Y_validation - diff[i]))
+            for i in range(len(sigmas))
+        ]
+        print("Mean Absolute (median-)Relative Error:", flush=True)
+        print("mare = " + ",".join([str(i) for i in mare]) + units, flush=True)
+        ### Calculate root-mean-squared-relative-error (RMSrE):
+        rmsre = [
+            multiplier * sqrt(mean(abs(Y_predicted[i] - Y_validation - diff[i]) ** 2))
+            for i in range(len(sigmas))
+        ]
+        print("Root Mean Squared (median-)Relative Error", flush=True)
+        print("rmsre = " + ",".join([str(i) for i in rmsre]) + units, flush=True)
+
+        if Qforces == 1:
+            multiplier = 627.503
+            units = " [kcal/mol/Angstrom]"
+            print("", flush=True)
+            print("Results for forces:", flush=True)
+            mae = [
+                multiplier * mean(abs(flatten(F_predicted[i]) - flatten(F_test)))
+                for i in range(len(sigmas))
+            ]
+            std = [
+                multiplier * std(abs(flatten(F_predicted[i]) - flatten(F_test)))
+                for i in range(len(sigmas))
+            ]
+            print(
+                "MAE = "
+                + ",".join([str(i) for i in mae])
+                + units
+                + "(+- "
+                + str(std[0])
+                + " )",
+                flush=True,
+            )
+            rmse = [
+                multiplier
+                * sqrt(mean(abs(flatten(F_predicted[i]) - flatten(F_test)) ** 2))
+                for i in range(len(sigmas))
+            ]
+            print("RMSE = " + ",".join([str(i) for i in rmse]) + units, flush=True)
+
+        if Qcharge == 1:
+            print("", flush=True)
+            print("Results for charges:", flush=True)
+            Qa_predicted = flatten(array([flatten(array(i)) for i in Qa_predicted]))
+            Q_charges = flatten(array([array(i) for i in Q_charges]))
+            mae = [mean(abs(Qa_predicted - Q_charges))]
+            print("MAE = " + ",".join([str(i) for i in mae]) + " e", flush=True)
+            rmse = [sqrt(mean(abs(Qa_predicted - Q_charges) ** 2))]
+            print("RMSE = " + ",".join([str(i) for i in rmse]) + " e", flush=True)
+
+        if err > 0:
+            Y_predicted = Y_predicted_rem
+            Y_validation = Y_validation_rem
+            if Qforces == 1:
+                F_predicted = F_predicted_rem
+
+    ### PRINTING THE QML PICKLES
+    for i in range(len(clustersout_df)):
+        if method != "delta":
+            clustersout_df.loc[
+                clustersout_df.iloc[i].name, (column_name_1, column_name_2)
+            ] = (Y_predicted[0][i] + ens_correction[i])
+        else:
+            clustersout_df.loc[
+                clustersout_df.iloc[i].name, (column_name_1, column_name_2)
+            ] = (Y_predicted[0][i] + form_ens2[i] + ens_correction[i])
+        if Qeval == 2:
+            clustersout_df.loc[clustersout_df.iloc[i].name, ("extra", "error")] = (
+                multiplier * abs(Y_predicted[0][i] - Y_validation[i])
+            )
+            clustersout_df.loc[clustersout_df.iloc[i].name, ("extra", "Y_true")] = (
+                multiplier * Y_validation[i]
+            )
+        if Qforces == 1:
+            if ("extra", "forces") not in clustersout_df.columns:
+                # clustersout_df.loc[clustersout_df.iloc[i].name,("extra","forces")] = [array(force) for force in F_predicted[0][i]]
+                clustersout_df.loc[:, ("extra", "forces")] = None
+            clustersout_df.at[clustersout_df.iloc[i].name, ("extra", "forces")] = [
+                array(force) for force in F_predicted[0][i]
+            ]
+    ### SAVE TIME AND SHAPE INFORMATION
+    clusters_df.loc[:, ("extra", "repr_train_wall")] = repr_train_wall
+    clusters_df.loc[:, ("extra", "repr_train_cpu")] = repr_train_cpu
+    clusters_df.loc[:, ("extra", "repr_test_wall")] = repr_test_wall
+    clusters_df.loc[:, ("extra", "repr_test_cpu")] = repr_test_cpu
+    clusters_df.loc[:, ("extra", "train_wall")] = train_wall
+    clusters_df.loc[:, ("extra", "train_cpu")] = train_cpu
+    clusters_df.loc[:, ("extra", "test_wall")] = test_wall
+    clusters_df.loc[:, ("extra", "test_cpu")] = test_cpu
+    clusters_df.loc[:, ("extra", "n_train")] = n_train
+    clusters_df.loc[:, ("extra", "d_train")] = d_train
+    clusters_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[0]
+    clusters_df.loc[:, ("extra", "d_test")] = d_test
+
+    clustersout_df.to_pickle(outfile)
+    if Qsampleeach > 0:
+        if sampleeach_i == 0:
+            os.system("JKQC " + outfile + " -out predicted_QML_FULL.pkl -noex")
+        else:
+            os.system(
+                "JKQC "
+                + outfile
+                + " predicted_QML_FULL.pkl -out predicted_QML_FULL.pkl -noex"
+            )
+
+    return

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -44,7 +44,7 @@ def print_results(
     d_test,
 ):
 
-    from numpy import array, isnan, mean, std, abs, sqrt, median
+    from numpy import array, isnan, mean, std, abs, sqrt, median, ndarray
 
     if Qwolfram == 0:
         lb = "["
@@ -291,7 +291,10 @@ def print_results(
     clustersout_df.loc[:, ("extra", "test_cpu")] = test_cpu
     clustersout_df.loc[:, ("extra", "n_train")] = n_train
     clustersout_df.loc[:, ("extra", "d_train")] = d_train
-    clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[1]
+    if isinstance(Y_predicted, list):
+        clustersout_df.loc[:, ("extra", "n_test")] = len(Y_predicted)
+    elif isinstance(Y_predicted, ndarray):
+        clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[1]
     clustersout_df.loc[:, ("extra", "d_test")] = d_test
 
     clustersout_df.to_pickle(outfile)

--- a/JKML/src/print_output.py
+++ b/JKML/src/print_output.py
@@ -291,7 +291,7 @@ def print_results(
     clustersout_df.loc[:, ("extra", "test_cpu")] = test_cpu
     clustersout_df.loc[:, ("extra", "n_train")] = n_train
     clustersout_df.loc[:, ("extra", "d_train")] = d_train
-    clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[0]
+    clustersout_df.loc[:, ("extra", "n_test")] = Y_predicted.shape[1]
     clustersout_df.loc[:, ("extra", "d_test")] = d_test
 
     clustersout_df.to_pickle(outfile)


### PR DESCRIPTION
This pull request introduces the k-NN model type to JKML. It should be noted that this PR is still a work in progress, and should not be merged before issues are addressed.

# Usage
## Basic modelling
`JKML -knn -repr [representation, one of [fchl, mbdf, fchl-kernel]] [-nometric] -train [trainset] -test [testset]`
Use the optional -nometric flag to skip metric learning and just use the Euclidean metric.

## Hyperparameters
Train hyperparameters and save to `path_to_hypercache`:
`JKML -knn -repr [representation, one of [fchl, mbdf, fchl-kernel]] [-nometric] -train [trainset] -hyper -varsout [path to hyper_cache]`

Use previously trained hyperparameters:
`JKML -knn -repr [representation, one of [fchl, mbdf, fchl-kernel]] [-nometric] -train [trainset] -test [testset] -hyper-cache [path to hyper_cache]`

# Features
- vanilla k-NN model with a number of representations supported
- k-NN with metric learning via [MLKR](https://contrib.scikit-learn.org/metric-learn/_modules/metric_learn/mlkr.html#MLKR)
- k-NN with induced kernel metric from the FCHL'18 kernel (requires compiling Fortran separately!)
- automated CV hyperparameter optimisation via [skopt](https://scikit-optimize.github.io/stable/) and hyperparameter loading for all of the above

# Requirements
Install the metric_learn library via
`pip install metric-learn`
and the scikit-optimize library via
`pip install scikit-optimize`

# Fortran compilation on Grendel
```
cd JKCS 2.1/JKML/src/fortran
ml load python/3.11.1
JKpython
f2py -m ffchl_vp_tree -c ffchl_kernel_types.f90 ffchl_kernels.f90 ffchl_module.f90 ffchl_kernel_distance.f90 fchl_vp_tree.f90 --fcompiler=gfortran --f90flags='-fopenmp' -lgomp
```

# Outstanding issues
- [ ] Python package management no updated to reflect new requirements
- [ ] Fortran compilation not automated for any of the supported environments
- [ ] Documentation lacking